### PR TITLE
feat: make ClassesManagerReborn an optional dependency

### DIFF
--- a/src/Classes/ASourFruitClass.cs
+++ b/src/Classes/ASourFruitClass.cs
@@ -35,6 +35,8 @@ namespace SWIP.Classes
 
         public override IEnumerator Init()
         {
+            if (!Plugin.UseClasses) yield break;
+
             while (!CardRegistry.TryGet("ASourFruit Entry", out _))
             {
                 yield return null;

--- a/src/Classes/SaucyEnchiladasClass.cs
+++ b/src/Classes/SaucyEnchiladasClass.cs
@@ -35,6 +35,8 @@ namespace SWIP.Classes
 
         public override IEnumerator Init()
         {
+            if (!Plugin.UseClasses) yield break;
+
             while (!CardRegistry.TryGet("SaucyEnchiladas Entry", out _))
             {
                 yield return null;

--- a/src/Classes/SynogenceClass.cs
+++ b/src/Classes/SynogenceClass.cs
@@ -35,6 +35,8 @@ namespace SWIP.Classes
 
         public override IEnumerator Init()
         {
+            if (!Plugin.UseClasses) yield break;
+
             while (!CardRegistry.TryGet("Synogence Entry", out _))
             {
                 yield return null;

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -1,4 +1,6 @@
 using BepInEx;
+using BepInEx.Bootstrap;
+using BepInEx.Configuration;
 using HarmonyLib;
 using UnboundLib.Cards;
 using UnityEngine;
@@ -9,7 +11,7 @@ namespace SWIP
     [BepInDependency("com.willis.rounds.unbound", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("pykess.rounds.plugins.moddingutils", BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency("root.rarity.lib", BepInDependency.DependencyFlags.HardDependency)]
-    [BepInDependency("root.classes.manager.reborn", BepInDependency.DependencyFlags.HardDependency)]
+    [BepInDependency("root.classes.manager.reborn", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInPlugin(ModId, ModName, Version)]
     [BepInProcess("Rounds.exe")]
     public class Plugin : BaseUnityPlugin
@@ -17,6 +19,8 @@ namespace SWIP
         private const string ModId = "com.sam.rounds.swip";
         private const string ModName = "SWIP";
         private const string Version = "2.0.0";
+
+        public static bool UseClasses;
 
         void Awake()
         {
@@ -26,6 +30,24 @@ namespace SWIP
             RarityLib.Utils.RarityUtils.AddRarity("Epic", 0.08f, new Color(0.6f, 0.2f, 0.8f), new Color(0.4f, 0.1f, 0.5f));
             RarityLib.Utils.RarityUtils.AddRarity("Legendary", 0.05f, new Color(1f, 0.84f, 0f), new Color(0.8f, 0.6f, 0f));
             RarityLib.Utils.RarityUtils.AddRarity("Mythic", 0.02f, new Color(1f, 0.2f, 0.8f), new Color(0.6f, 0.1f, 0.5f));
+
+            bool cmrPresent = Chainloader.PluginInfos.ContainsKey("root.classes.manager.reborn");
+
+            var cfgUseClasses = Config.Bind(
+                "General",
+                "UseClasses",
+                cmrPresent,
+                "Enable class gating (requires ClassesManagerReborn). When false, all cards are a flat pool."
+            );
+
+            if (cfgUseClasses.Value && !cmrPresent)
+            {
+                Logger.LogWarning("[SWIP] UseClasses enabled but ClassesManagerReborn not installed. Forcing to false.");
+                cfgUseClasses.Value = false;
+            }
+
+            UseClasses = cfgUseClasses.Value;
+            Logger.LogInfo($"[SWIP] UseClasses = {UseClasses} (CMR present: {cmrPresent})");
         }
 
         void Start()


### PR DESCRIPTION
## Summary
- Change CMR from a hard BepInEx dependency to a soft dependency so SWIP loads without it
- Add runtime detection via `Chainloader.PluginInfos` and a `UseClasses` config toggle
- Guard all three class handler `Init()` methods with `yield break` when classes are disabled

## Behavior

| CMR installed | UseClasses | Result |
|---|---|---|
| Yes | `true` (default) | Class gating active — same as today |
| Yes | `false` (override) | Flat 99-card pool, handlers bail early |
| No | `false` (default) | Flat 99-card pool, no crash |
| No | `true` (mistake) | Forced to `false` + warning log |

## Test plan
- [ ] Build passes with `dotnet build src/SWIP.csproj -c Release` (verified)
- [ ] Launch ROUNDS with CMR installed — classes work as before
- [ ] Launch ROUNDS without CMR — all 99 cards appear in flat pool, no crash
- [ ] Set `UseClasses = false` in config with CMR installed — flat pool, no class gating
- [ ] Set `UseClasses = true` without CMR — warning logged, forced to false