### PR TITLE
feat: add ~50 silly/chaos unclassed cards (v2.3.0)

### DIFF
--- a/src/Cards/AllIn.cs
+++ b/src/Cards/AllIn.cs
@@ -1,0 +1,72 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class AllInStorage : MonoBehaviour
+    {
+        public float origDamage;
+        public float origAttackSpeed;
+        public float origMoveSpeed;
+        public float origMaxHealth;
+        public float origProjSpeed;
+    }
+
+    public class AllIn : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.AddComponent<AllInStorage>();
+            store.origDamage = gun.damage;
+            store.origAttackSpeed = gun.attackSpeed;
+            store.origMoveSpeed = characterStats.movementSpeed;
+            store.origMaxHealth = data.maxHealth;
+            store.origProjSpeed = gun.projectileSpeed;
+
+            gun.damage *= Random.Range(0.5f, 1.5f);
+            gun.attackSpeed *= Random.Range(0.5f, 1.5f);
+            characterStats.movementSpeed *= Random.Range(0.5f, 1.5f);
+            data.maxHealth *= Random.Range(0.5f, 1.5f);
+            gun.projectileSpeed *= Random.Range(0.5f, 1.5f);
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.GetComponent<AllInStorage>();
+            if (store != null)
+            {
+                gun.damage = store.origDamage;
+                gun.attackSpeed = store.origAttackSpeed;
+                characterStats.movementSpeed = store.origMoveSpeed;
+                data.maxHealth = store.origMaxHealth;
+                gun.projectileSpeed = store.origProjSpeed;
+                Object.Destroy(store);
+            }
+        }
+
+        protected override string GetTitle() => "All In";
+        protected override string GetDescription() => "Everything changes. No refunds.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "Randomize All Stats +/-50%",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/AllInOne.cs
+++ b/src/Cards/AllInOne.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using ModdingUtils.Utils;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class AllInOne : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            if (data.currentCards.Count == 0) return;
+
+            var chosen = data.currentCards[UnityEngine.Random.Range(0, data.currentCards.Count)];
+            int count = data.currentCards.Count;
+
+            ModdingUtils.Utils.Cards.instance.RemoveAllCardsFromPlayer(player);
+
+            for (int i = 0; i < count; i++)
+            {
+                ModdingUtils.Utils.Cards.instance.AddCardToPlayer(player, chosen, false, "", 0f, 0f, true);
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("All-In-One Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "All-In-One")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "All-In-One";
+        protected override string GetDescription() => "One card to rule them all.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "All Cards Become", amount = "One", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/AllInOnePlaceholder.cs
+++ b/src/Cards/AllInOnePlaceholder.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "All-In-One" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class AllInOnePlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "All-In-One Used";
+        protected override string GetDescription() => "All your cards became one. That's the power of unity.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Unified", amount = "Cards", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/AngryBirds.cs
+++ b/src/Cards/AngryBirds.cs
@@ -1,0 +1,50 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class AngryBirds : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.damage *= 0.7f;
+
+            var e = player.gameObject.AddComponent<HomingBirdEffect>();
+            e.birdCount = 2;
+            e.birdDamage = 20f;
+            e.birdSpeed = 12f;
+            e.birdLifetime = 5f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.damage /= 0.7f;
+
+            var e = player.gameObject.GetComponent<HomingBirdEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Angry Birds";
+        protected override string GetDescription() => "They're not actually angry. They're FURIOUS.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Homing Birds", amount = "2 per shot", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-30%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.DestructiveRed;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BounceX10.cs
+++ b/src/Cards/BounceX10.cs
@@ -1,0 +1,41 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class BounceX10 : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 10;
+            gun.damage *= 0.8f;
+            player.gameObject.AddComponent<ScreenBounceSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 10;
+            gun.damage /= 0.8f;
+            var s = player.gameObject.GetComponent<ScreenBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bounce x10";
+        protected override string GetDescription() => "Your bullet has commitment issues.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+10", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-20%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BounceX100.cs
+++ b/src/Cards/BounceX100.cs
@@ -1,0 +1,45 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class BounceX100 : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 100;
+            gun.damage *= 0.5f;
+            gun.projectileSpeed *= 0.7f;
+            player.gameObject.AddComponent<ScreenBounceSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 100;
+            gun.damage /= 0.5f;
+            gun.projectileSpeed /= 0.7f;
+            var s = player.gameObject.GetComponent<ScreenBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bounce x100";
+        protected override string GetDescription() => "The bullet will outlive us all.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+100", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-50%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Bullet Speed", amount = "-30%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BounceX2.cs
+++ b/src/Cards/BounceX2.cs
@@ -1,0 +1,39 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class BounceX2 : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 2;
+            player.gameObject.AddComponent<ScreenBounceSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 2;
+            var s = player.gameObject.GetComponent<ScreenBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bounce x2";
+        protected override string GetDescription() => "Boing.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Screen Bounce", amount = "Yes", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Common;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BounceX25.cs
+++ b/src/Cards/BounceX25.cs
@@ -1,0 +1,41 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class BounceX25 : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 25;
+            gun.damage *= 0.7f;
+            player.gameObject.AddComponent<ScreenBounceSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 25;
+            gun.damage /= 0.7f;
+            var s = player.gameObject.GetComponent<ScreenBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bounce x25";
+        protected override string GetDescription() => "The bullet forgot where it was going.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+25", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-30%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BounceX5.cs
+++ b/src/Cards/BounceX5.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class BounceX5 : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 5;
+            gun.damage *= 0.9f;
+            player.gameObject.AddComponent<ScreenBounceSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 5;
+            gun.damage /= 0.9f;
+            var s = player.gameObject.GetComponent<ScreenBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bounce x5";
+        protected override string GetDescription() => "Boing boing boing boing boing.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+5", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Screen Bounce", amount = "Yes", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-10%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Common;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BounceX50.cs
+++ b/src/Cards/BounceX50.cs
@@ -1,0 +1,45 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class BounceX50 : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 50;
+            gun.damage *= 0.6f;
+            gun.projectileSpeed *= 0.8f;
+            player.gameObject.AddComponent<ScreenBounceSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 50;
+            gun.damage /= 0.6f;
+            gun.projectileSpeed /= 0.8f;
+            var s = player.gameObject.GetComponent<ScreenBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bounce x50";
+        protected override string GetDescription() => "Is that YOUR bullet or a screensaver?";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+50", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-40%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Bullet Speed", amount = "-20%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BrotherlyLove.cs
+++ b/src/Cards/BrotherlyLove.cs
@@ -9,16 +9,32 @@ namespace SWIP.Cards
     public class BrotherlyLove : CustomCard
     {
         // Cards that re-trigger dangerous effects when re-added via swap
-        private static readonly HashSet<string> dangerousCards = new HashSet<string>
+        public static readonly HashSet<string> dangerousCards = new HashSet<string>
         {
             "Mom Said It's My Turn",
-            "Brotherly Love"
+            "Brotherly Love",
+            "New Hand",
+            "All-In-One",
+            "Card Thief",
+            "Shuffle & Deal",
+            "Card Tornado",
+            "High Stakes",
+            "Stat Leech",
+            "Copycat"
         };
 
-        private static readonly Dictionary<string, string> replacements = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> replacements = new Dictionary<string, string>
         {
             { "Mom Said It's My Turn", "Yay It's My Turn!" },
-            { "Brotherly Love", "Sharing is Caring" }
+            { "Brotherly Love", "Sharing is Caring" },
+            { "New Hand", "New Hand Used" },
+            { "All-In-One", "All-In-One Used" },
+            { "Card Thief", "Card Thief Used" },
+            { "Shuffle & Deal", "Shuffle & Deal Used" },
+            { "Card Tornado", "Card Tornado Used" },
+            { "High Stakes", "High Stakes Used" },
+            { "Stat Leech", "Stat Leech Used" },
+            { "Copycat", "Copycat Used" }
         };
 
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)

--- a/src/Cards/BulletFlood.cs
+++ b/src/Cards/BulletFlood.cs
@@ -1,0 +1,41 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class BulletFlood : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles += 25;
+            gun.spread += 1.0f;
+            gun.damage *= 0.3f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles -= 25;
+            gun.spread -= 1.0f;
+            gun.damage /= 0.3f;
+        }
+
+        protected override string GetTitle() => "Bullet Flood";
+        protected override string GetDescription() => "The screen is now made of bullets.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bullets", amount = "+25", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Spread", amount = "+1.0", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-70%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BulletHail.cs
+++ b/src/Cards/BulletHail.cs
@@ -1,0 +1,40 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class BulletHail : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles += 10;
+            gun.spread += 0.6f;
+            gun.damage *= 0.5f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles -= 10;
+            gun.spread -= 0.6f;
+            gun.damage /= 0.5f;
+        }
+
+        protected override string GetTitle() => "Bullet Hail";
+        protected override string GetDescription() => "Death by a thousand papercuts.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bullets", amount = "+10", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Spread", amount = "+0.6", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-50%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BulletSpeedPlus.cs
+++ b/src/Cards/BulletSpeedPlus.cs
@@ -1,0 +1,34 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class BulletSpeedPlus : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.projectileSpeed *= 1.5f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.projectileSpeed /= 1.5f;
+        }
+
+        protected override string GetTitle() => "Bullet Speed+";
+        protected override string GetDescription() => "Zoom.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bullet Speed", amount = "+50%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Common;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BulletStorm.cs
+++ b/src/Cards/BulletStorm.cs
@@ -1,0 +1,40 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class BulletStorm : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles += 5;
+            gun.spread += 0.4f;
+            gun.damage *= 0.7f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles -= 5;
+            gun.spread -= 0.4f;
+            gun.damage /= 0.7f;
+        }
+
+        protected override string GetTitle() => "Bullet Storm";
+        protected override string GetDescription() => "Accuracy? Never heard of her.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bullets", amount = "+5", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Spread", amount = "+0.4", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-30%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/BulletWarp.cs
+++ b/src/Cards/BulletWarp.cs
@@ -1,0 +1,54 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class BulletWarp : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            player.gameObject.AddComponent<TeleportToBulletSpawner>();
+            data.maxHealth *= 0.6f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            data.maxHealth /= 0.6f;
+            var s = player.gameObject.GetComponent<TeleportToBulletSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Bullet Warp";
+        protected override string GetDescription() => "You ARE the bullet now.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "Teleport to Bullet Hit",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                },
+                new CardInfoStat
+                {
+                    positive = false,
+                    stat = "HP",
+                    amount = "-40%",
+                    simepleAmount = CardInfoStat.SimpleAmount.lower
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/CardThief.cs
+++ b/src/Cards/CardThief.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using ModdingUtils.Utils;
+
+namespace SWIP.Cards
+{
+    public class CardThief : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var others = PlayerManager.instance.players.FindAll(p => p != player && !p.data.dead);
+
+            foreach (var other in others)
+            {
+                if (other.data.currentCards.Count == 0) continue;
+
+                int idx = UnityEngine.Random.Range(0, other.data.currentCards.Count);
+                var random = ModdingUtils.Utils.Cards.instance.GetRandomCardWithCondition(
+                    player, gun, gunAmmo, data, health, gravity, block, characterStats,
+                    (ci, p, g, ga, d, h, gr, b, cs) => true
+                );
+                if (random != null)
+                {
+                    other.data.currentCards[idx] = random;
+                }
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("Card Thief Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "Card Thief")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Card Thief";
+        protected override string GetDescription() => "What's yours is... also yours, but different.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Others Swap", amount = "1 Random Card", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/CardThiefPlaceholder.cs
+++ b/src/Cards/CardThiefPlaceholder.cs
@@ -1,0 +1,41 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "Card Thief" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class CardThiefPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Card Thief Used";
+        protected override string GetDescription() => "You made them swap. That's that.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Stolen", amount = "Cards", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/CardTornado.cs
+++ b/src/Cards/CardTornado.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using ModdingUtils.Utils;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class CardTornado : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var allPlayers = PlayerManager.instance.players;
+            var pool = new List<CardInfo>();
+            var counts = new int[allPlayers.Count];
+
+            for (int i = 0; i < allPlayers.Count; i++)
+            {
+                counts[i] = allPlayers[i].data.currentCards.Count;
+                foreach (var card in allPlayers[i].data.currentCards)
+                {
+                    // Skip this card to avoid recursive manipulation
+                    if (card.cardName != "Card Tornado")
+                    {
+                        pool.Add(card);
+                    }
+                }
+            }
+
+            // Fisher-Yates shuffle
+            for (int i = pool.Count - 1; i > 0; i--)
+            {
+                int j = UnityEngine.Random.Range(0, i + 1);
+                var temp = pool[i];
+                pool[i] = pool[j];
+                pool[j] = temp;
+            }
+
+            // Remove all cards from all players
+            foreach (var p in allPlayers)
+            {
+                ModdingUtils.Utils.Cards.instance.RemoveAllCardsFromPlayer(p);
+            }
+
+            // Redistribute from the shuffled pool
+            int poolIdx = 0;
+            for (int i = 0; i < allPlayers.Count; i++)
+            {
+                for (int j = 0; j < counts[i] && poolIdx < pool.Count; j++)
+                {
+                    ModdingUtils.Utils.Cards.instance.AddCardToPlayer(allPlayers[i], pool[poolIdx], false, "", 0f, 0f, true);
+                    poolIdx++;
+                }
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("Card Tornado Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "Card Tornado")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Card Tornado";
+        protected override string GetDescription() => "Cards go up. Cards come down. Nobody knows whose is whose.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Pool & Redistribute", amount = "All Cards", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/CardTornadoPlaceholder.cs
+++ b/src/Cards/CardTornadoPlaceholder.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "Card Tornado" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class CardTornadoPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Card Tornado Used";
+        protected override string GetDescription() => "The tornado has passed. Pick up the pieces.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Redistributed", amount = "Cards", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ChaosRicochet.cs
+++ b/src/Cards/ChaosRicochet.cs
@@ -1,0 +1,45 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class ChaosRicochet : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 3;
+
+            player.gameObject.AddComponent<ChaosRicochetSpawner>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 3;
+
+            var s = player.gameObject.GetComponent<ChaosRicochetSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Chaos Ricochet";
+        protected override string GetDescription() => "Physics left the chat.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Swap Damage/Speed", amount = "On Bounce", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+3", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ChaosStats.cs
+++ b/src/Cards/ChaosStats.cs
@@ -1,0 +1,73 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class ChaosStatsStorage : MonoBehaviour
+    {
+        public float origDamage;
+        public float origAttackSpeed;
+        public float origMoveSpeed;
+        public float origMaxHealth;
+    }
+
+    public class ChaosStats : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.AddComponent<ChaosStatsStorage>();
+            store.origDamage = gun.damage;
+            store.origAttackSpeed = gun.attackSpeed;
+            store.origMoveSpeed = characterStats.movementSpeed;
+            store.origMaxHealth = data.maxHealth;
+
+            float[] mults = new float[] { 1f, 1f, 1f, 1f };
+            int idx1 = Random.Range(0, 4);
+            int idx2 = (idx1 + Random.Range(1, 4)) % 4;
+            mults[idx1] = Random.Range(0.5f, 2f);
+            mults[idx2] = Random.Range(0.5f, 2f);
+
+            gun.damage *= mults[0];
+            gun.attackSpeed *= (2f - mults[1]);
+            characterStats.movementSpeed *= mults[2];
+            data.maxHealth *= mults[3];
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.GetComponent<ChaosStatsStorage>();
+            if (store != null)
+            {
+                gun.damage = store.origDamage;
+                gun.attackSpeed = store.origAttackSpeed;
+                characterStats.movementSpeed = store.origMoveSpeed;
+                data.maxHealth = store.origMaxHealth;
+                Object.Destroy(store);
+            }
+        }
+
+        protected override string GetTitle() => "Chaos Stats";
+        protected override string GetDescription() => "Roll the dice on your build.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "Randomize 2 Stats",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ClipApocalypse.cs
+++ b/src/Cards/ClipApocalypse.cs
@@ -1,0 +1,49 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class ClipApocalypse : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo += 15;
+            gun.damage *= 0.5f;
+
+            player.gameObject.AddComponent<ClipDumpEffect>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo -= 15;
+            gun.damage /= 0.5f;
+
+            var e = player.gameObject.GetComponent<ClipDumpEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Clip Apocalypse";
+        protected override string GetDescription() => "It's raining lead, hallelujah.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Ammo", amount = "+15", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Clip Dump", amount = "Enabled", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-50%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ClipDump.cs
+++ b/src/Cards/ClipDump.cs
@@ -1,0 +1,48 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class ClipDump : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo += 3;
+            gun.damage *= 0.8f;
+
+            player.gameObject.AddComponent<ClipDumpEffect>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo -= 3;
+            gun.damage /= 0.8f;
+
+            var e = player.gameObject.GetComponent<ClipDumpEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Clip Dump";
+        protected override string GetDescription() => "Empty the magazine. Ask questions never.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Ammo", amount = "+3", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Clip Dump", amount = "Enabled", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-20%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ClipPurge.cs
+++ b/src/Cards/ClipPurge.cs
@@ -1,0 +1,48 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class ClipPurge : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo += 8;
+            gun.damage *= 0.65f;
+
+            player.gameObject.AddComponent<ClipDumpEffect>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo -= 8;
+            gun.damage /= 0.65f;
+
+            var e = player.gameObject.GetComponent<ClipDumpEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Clip Purge";
+        protected override string GetDescription() => "All bullets must go. Now.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Ammo", amount = "+8", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Clip Dump", amount = "Enabled", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-35%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/Copycat.cs
+++ b/src/Cards/Copycat.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using ModdingUtils.Utils;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class Copycat : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Collect all cards from all players, excluding this card
+            var allCards = new List<CardInfo>();
+            foreach (var p in PlayerManager.instance.players)
+            {
+                foreach (var c in p.data.currentCards)
+                {
+                    if (c.cardName != "Copycat")
+                    {
+                        allCards.Add(c);
+                    }
+                }
+            }
+
+            if (allCards.Count == 0) return;
+
+            var chosen = allCards[UnityEngine.Random.Range(0, allCards.Count)];
+            int myCount = data.currentCards.Count;
+
+            ModdingUtils.Utils.Cards.instance.RemoveAllCardsFromPlayer(player);
+
+            for (int i = 0; i < myCount; i++)
+            {
+                ModdingUtils.Utils.Cards.instance.AddCardToPlayer(player, chosen, false, "", 0f, 0f, true);
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("Copycat Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "Copycat")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Copycat";
+        protected override string GetDescription() => "Imitation is the sincerest form of theft.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Clone Any Card", amount = "For Entire Hand", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/CopycatPlaceholder.cs
+++ b/src/Cards/CopycatPlaceholder.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "Copycat" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class CopycatPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Copycat Used";
+        protected override string GetDescription() => "You copied someone else's homework.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Cloned", amount = "Cards", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/DoubleDown.cs
+++ b/src/Cards/DoubleDown.cs
@@ -1,0 +1,67 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class DoubleDownStorage : MonoBehaviour
+    {
+        public float dmgMult;
+        public float spdMult;
+        public float movMult;
+        public float hpMult;
+    }
+
+    public class DoubleDown : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.AddComponent<DoubleDownStorage>();
+            store.dmgMult = 1f;
+            store.spdMult = 1f;
+            store.movMult = 1f;
+            store.hpMult = 1f;
+
+            if (gun.damage < 1f) { float m = Random.value > 0.5f ? 2f : 0.5f; store.dmgMult = m; gun.damage *= m; }
+            if (gun.attackSpeed > 1f) { float m = Random.value > 0.5f ? 0.5f : 2f; store.spdMult = m; gun.attackSpeed *= m; }
+            if (characterStats.movementSpeed < 1f) { float m = Random.value > 0.5f ? 2f : 0.5f; store.movMult = m; characterStats.movementSpeed *= m; }
+            if (data.maxHealth < 100f) { float m = Random.value > 0.5f ? 2f : 0.5f; store.hpMult = m; data.maxHealth *= m; }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.GetComponent<DoubleDownStorage>();
+            if (store != null)
+            {
+                gun.damage /= store.dmgMult;
+                gun.attackSpeed /= store.spdMult;
+                characterStats.movementSpeed /= store.movMult;
+                data.maxHealth /= store.hpMult;
+                Object.Destroy(store);
+            }
+        }
+
+        protected override string GetTitle() => "Double Down";
+        protected override string GetDescription() => "Feeling lucky, punk?";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "50/50 Double/Halve Weak Stats",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/EffectAmplifier.cs
+++ b/src/Cards/EffectAmplifier.cs
@@ -1,0 +1,90 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class EffectAmplifier : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            foreach (var cloud in player.gameObject.GetComponents<CloudEffectSpawner>())
+            {
+                cloud.cloudRadius *= 1.5f;
+                cloud.damagePerSecond *= 1.5f;
+                cloud.healPerSecond *= 1.5f;
+            }
+
+            foreach (var burn in player.gameObject.GetComponents<ScorchingBounceSpawner>())
+            {
+                burn.baseBurnDps *= 1.5f;
+                burn.burnRadius *= 1.5f;
+            }
+
+            foreach (var vortex in player.gameObject.GetComponents<VortexBounceSpawner>())
+            {
+                vortex.pullRadius *= 1.5f;
+                vortex.pullForce *= 1.5f;
+            }
+
+            foreach (var shock in player.gameObject.GetComponents<ShockwaveBounceSpawner>())
+            {
+                shock.pushRadius *= 1.5f;
+                shock.pushForce *= 1.5f;
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            foreach (var cloud in player.gameObject.GetComponents<CloudEffectSpawner>())
+            {
+                cloud.cloudRadius /= 1.5f;
+                cloud.damagePerSecond /= 1.5f;
+                cloud.healPerSecond /= 1.5f;
+            }
+
+            foreach (var burn in player.gameObject.GetComponents<ScorchingBounceSpawner>())
+            {
+                burn.baseBurnDps /= 1.5f;
+                burn.burnRadius /= 1.5f;
+            }
+
+            foreach (var vortex in player.gameObject.GetComponents<VortexBounceSpawner>())
+            {
+                vortex.pullRadius /= 1.5f;
+                vortex.pullForce /= 1.5f;
+            }
+
+            foreach (var shock in player.gameObject.GetComponents<ShockwaveBounceSpawner>())
+            {
+                shock.pushRadius /= 1.5f;
+                shock.pushForce /= 1.5f;
+            }
+        }
+
+        protected override string GetTitle() => "Effect Amplifier";
+        protected override string GetDescription() => "Whatever you're doing, do it LOUDER.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "All Effect Sizes x1.5",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.MagicPink;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/Featherfall.cs
+++ b/src/Cards/Featherfall.cs
@@ -1,0 +1,46 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class Featherfall : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 2;
+
+            var s = player.gameObject.AddComponent<FeatherfallBounceSpawner>();
+            s.gravityReductionPerBounce = 0.3f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 2;
+
+            var s = player.gameObject.GetComponent<FeatherfallBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Featherfall";
+        protected override string GetDescription() => "Gravity is just a suggestion.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Gravity Per Bounce", amount = "-30%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.ColdBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/HighStakes.cs
+++ b/src/Cards/HighStakes.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class HighStakes : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var others = PlayerManager.instance.players.FindAll(p => p != player && !p.data.dead);
+            if (others.Count == 0) return;
+
+            var target = others[UnityEngine.Random.Range(0, others.Count)];
+            var targetGun = target.GetComponentInChildren<Gun>();
+
+            if (UnityEngine.Random.value > 0.5f)
+            {
+                // Win: steal 20% of target's damage and health
+                float stolenDmg = targetGun.damage * 0.2f;
+                float stolenHp = target.data.maxHealth * 0.2f;
+                targetGun.damage *= 0.8f;
+                target.data.maxHealth *= 0.8f;
+                gun.damage += stolenDmg;
+                data.maxHealth += stolenHp;
+            }
+            else
+            {
+                // Lose: give 20% of your damage and health to target
+                float lostDmg = gun.damage * 0.2f;
+                float lostHp = data.maxHealth * 0.2f;
+                gun.damage *= 0.8f;
+                data.maxHealth *= 0.8f;
+                targetGun.damage += lostDmg;
+                target.data.maxHealth += lostHp;
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("High Stakes Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "High Stakes")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "High Stakes";
+        protected override string GetDescription() => "Win big or lose bigger.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "50/50", amount = "Steal or Lose Stats", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/HighStakesPlaceholder.cs
+++ b/src/Cards/HighStakesPlaceholder.cs
@@ -1,0 +1,41 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "High Stakes" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class HighStakesPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "High Stakes Used";
+        protected override string GetDescription() => "You gambled. The house always wins.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Gambled", amount = "Stats", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/IceRicochet.cs
+++ b/src/Cards/IceRicochet.cs
@@ -1,0 +1,48 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class IceRicochet : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 2;
+
+            var s = player.gameObject.AddComponent<IceRicochetSpawner>();
+            s.freezeRadius = 4f;
+            s.slowPercent = 0.4f;
+            s.freezeDuration = 2f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 2;
+
+            var s = player.gameObject.GetComponent<IceRicochetSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Ice Ricochet";
+        protected override string GetDescription() => "Freeze tag, bullet edition.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Slow on Bounce", amount = "40%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.ColdBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/InfiniteAmmo.cs
+++ b/src/Cards/InfiniteAmmo.cs
@@ -1,0 +1,38 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class InfiniteAmmo : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo += 999;
+            gun.damage *= 0.6f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gunAmmo.maxAmmo -= 999;
+            gun.damage /= 0.6f;
+        }
+
+        protected override string GetTitle() => "Infinite Ammo";
+        protected override string GetDescription() => "Ammo is a suggestion, not a rule.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Ammo", amount = "+999", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-40%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Legendary");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/LemonDrop.cs
+++ b/src/Cards/LemonDrop.cs
@@ -1,0 +1,44 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class LemonDrop : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.AddComponent<LemonDropSpawner>();
+            s.blindRadius = 3f;
+            s.blindDuration = 2f;
+            s.slowAmount = 0.6f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.GetComponent<LemonDropSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Lemon Drop";
+        protected override string GetDescription() => "When life gives you lemons, blind your enemies.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Lemon Zones", amount = "On Hit/Bounce", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Slow Enemies", amount = "60%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/NachoBlock.cs
+++ b/src/Cards/NachoBlock.cs
@@ -1,0 +1,46 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class NachoBlock : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var e = player.gameObject.AddComponent<NachosOnBlockEffect>();
+            e.nachoCount = 5;
+            e.nachoDamage = 10f;
+            e.nachoHeal = 5f;
+            e.nachoSpeed = 8f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var e = player.gameObject.GetComponent<NachosOnBlockEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Nacho Block";
+        protected override string GetDescription() => "Blocked! Have some nachos.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Spawn Nachos", amount = "On Block", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Heal Allies", amount = "5 HP", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Damage Enemies", amount = "10 dmg", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/NewHand.cs
+++ b/src/Cards/NewHand.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using ModdingUtils.Utils;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class NewHand : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            int cardCount = data.currentCards.Count;
+            ModdingUtils.Utils.Cards.instance.RemoveAllCardsFromPlayer(player);
+
+            for (int i = 0; i < cardCount; i++)
+            {
+                var random = ModdingUtils.Utils.Cards.instance.GetRandomCardWithCondition(
+                    player, gun, gunAmmo, data, health, gravity, block, characterStats,
+                    (ci, p, g, ga, d, h, gr, b, cs) => true
+                );
+                if (random != null)
+                {
+                    ModdingUtils.Utils.Cards.instance.AddCardToPlayer(player, random, false, "", 0f, 0f, true);
+                }
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("New Hand Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "New Hand")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "New Hand";
+        protected override string GetDescription() => "Throw away everything. Start fresh. Regret nothing.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Replace All Cards", amount = "Random Hand", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/NewHandPlaceholder.cs
+++ b/src/Cards/NewHandPlaceholder.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "New Hand" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class NewHandPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "New Hand Used";
+        protected override string GetDescription() => "You drew a new hand. No takebacks.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Redrawn", amount = "Hand", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/QuickDraw.cs
+++ b/src/Cards/QuickDraw.cs
@@ -1,0 +1,34 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class QuickDraw : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reloadTime *= 0.01f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reloadTime /= 0.01f;
+        }
+
+        protected override string GetTitle() => "Quick Draw";
+        protected override string GetDescription() => "Reload? What reload?";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Reload Time", amount = "x0.01", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/RadialSpread.cs
+++ b/src/Cards/RadialSpread.cs
@@ -1,0 +1,40 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class RadialSpread : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles += 2;
+            gun.spread = 0f;
+            player.gameObject.AddComponent<RadialShotEffect>();
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.numberOfProjectiles -= 2;
+            var effect = player.gameObject.GetComponent<RadialShotEffect>();
+            if (effect != null) Object.Destroy(effect);
+        }
+
+        protected override string GetTitle() => "Radial Spread";
+        protected override string GetDescription() => "Why aim when you can cover everything?";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Bullets", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Radial Pattern", amount = "Yes", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/RapidFire.cs
+++ b/src/Cards/RapidFire.cs
@@ -1,0 +1,37 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class RapidFire : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.attackSpeed *= 0.6f;
+            gun.damage *= 0.8f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.attackSpeed /= 0.6f;
+            gun.damage /= 0.8f;
+        }
+
+        protected override string GetTitle() => "Rapid Fire";
+        protected override string GetDescription() => "Brrrrrrrrrt.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Fire Rate", amount = "+40%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-20%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Common;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/RicochetRoulette.cs
+++ b/src/Cards/RicochetRoulette.cs
@@ -1,0 +1,47 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class RicochetRoulette : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 3;
+
+            var s = player.gameObject.AddComponent<BounceRandomSizeSpawner>();
+            s.speedMultPerBounce = 1.15f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 3;
+
+            var s = player.gameObject.GetComponent<BounceRandomSizeSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Ricochet Roulette";
+        protected override string GetDescription() => "Every bounce is a surprise.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Random Size on Bounce", amount = "Enabled", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Speed on Bounce", amount = "+15%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+3", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/RisingTide.cs
+++ b/src/Cards/RisingTide.cs
@@ -1,0 +1,67 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class RisingTideStorage : MonoBehaviour
+    {
+        public float dmgMult;
+        public float spdMult;
+        public float movMult;
+        public float hpMult;
+    }
+
+    public class RisingTide : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.AddComponent<RisingTideStorage>();
+            store.dmgMult = 1f;
+            store.spdMult = 1f;
+            store.movMult = 1f;
+            store.hpMult = 1f;
+
+            if (gun.damage > 1f) { store.dmgMult = 1.2f; gun.damage *= 1.2f; }
+            if (gun.attackSpeed < 1f) { store.spdMult = 0.8f; gun.attackSpeed *= 0.8f; }
+            if (characterStats.movementSpeed > 1f) { store.movMult = 1.2f; characterStats.movementSpeed *= 1.2f; }
+            if (data.maxHealth > 100f) { store.hpMult = 1.2f; data.maxHealth *= 1.2f; }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.GetComponent<RisingTideStorage>();
+            if (store != null)
+            {
+                gun.damage /= store.dmgMult;
+                gun.attackSpeed /= store.spdMult;
+                characterStats.movementSpeed /= store.movMult;
+                data.maxHealth /= store.hpMult;
+                Object.Destroy(store);
+            }
+        }
+
+        protected override string GetTitle() => "Rising Tide";
+        protected override string GetDescription() => "The rich get richer.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "+20% to Above-Average Stats",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.NatureBrown;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ScorchingBounce.cs
+++ b/src/Cards/ScorchingBounce.cs
@@ -1,0 +1,49 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class ScorchingBounce : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 3;
+
+            var s = player.gameObject.AddComponent<ScorchingBounceSpawner>();
+            s.burnRadius = 4f;
+            s.baseBurnDps = 5f;
+            s.burnDuration = 2f;
+            s.escalation = 1.5f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 3;
+
+            var s = player.gameObject.GetComponent<ScorchingBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Scorching Bounce";
+        protected override string GetDescription() => "Each bounce fans the flames.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Burn on Bounce", amount = "Escalates", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+3", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.DestructiveRed;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ShockwaveBounce.cs
+++ b/src/Cards/ShockwaveBounce.cs
@@ -1,0 +1,47 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class ShockwaveBounce : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 2;
+
+            var s = player.gameObject.AddComponent<ShockwaveBounceSpawner>();
+            s.pushRadius = 5f;
+            s.pushForce = 1200f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 2;
+
+            var s = player.gameObject.GetComponent<ShockwaveBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Shockwave Bounce";
+        protected override string GetDescription() => "Personal space enforcer.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Push Enemies", amount = "On Bounce", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.DefensiveBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ShuffleAndDeal.cs
+++ b/src/Cards/ShuffleAndDeal.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using ModdingUtils.Utils;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class ShuffleAndDeal : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var others = PlayerManager.instance.players.FindAll(p => p != player && !p.data.dead);
+
+            foreach (var other in others)
+            {
+                int count = other.data.currentCards.Count;
+                if (count == 0) continue;
+
+                var otherGun = other.GetComponentInChildren<Gun>();
+                var otherAmmo = other.GetComponentInChildren<GunAmmo>();
+
+                ModdingUtils.Utils.Cards.instance.RemoveAllCardsFromPlayer(other);
+
+                for (int i = 0; i < count; i++)
+                {
+                    var random = ModdingUtils.Utils.Cards.instance.GetRandomCardWithCondition(
+                        other, otherGun, otherAmmo, other.data, other.data.healthHandler,
+                        other.GetComponent<Gravity>(), other.GetComponent<Block>(), other.data.stats,
+                        (ci, p, g, ga, d, h, gr, b, cs) => true
+                    );
+                    if (random != null)
+                    {
+                        ModdingUtils.Utils.Cards.instance.AddCardToPlayer(other, random, false, "", 0f, 0f, true);
+                    }
+                }
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("Shuffle & Deal Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "Shuffle & Deal")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Shuffle & Deal";
+        protected override string GetDescription() => "Dealer takes all. And redistributes poorly.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Others Shuffle", amount = "All Cards", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/ShuffleDealPlaceholder.cs
+++ b/src/Cards/ShuffleDealPlaceholder.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "Shuffle &amp; Deal" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class ShuffleDealPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Shuffle & Deal Used";
+        protected override string GetDescription() => "The cards have been reshuffled.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Shuffled", amount = "Decks", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/SlowDrip.cs
+++ b/src/Cards/SlowDrip.cs
@@ -1,0 +1,39 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class SlowDrip : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.AddComponent<SlowOnHitSpawner>();
+            s.slowPercent = 0.1f;
+            s.slowDuration = 2f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.GetComponent<SlowOnHitSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Slow Drip";
+        protected override string GetDescription() => "Just a little... sluggish.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Slow", amount = "10%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Duration", amount = "2s", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Common;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.ColdBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/SlowPour.cs
+++ b/src/Cards/SlowPour.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class SlowPour : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.AddComponent<SlowOnHitSpawner>();
+            s.slowPercent = 0.25f;
+            s.slowDuration = 3f;
+            gun.damage *= 0.9f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.GetComponent<SlowOnHitSpawner>();
+            if (s != null) Object.Destroy(s);
+            gun.damage /= 0.9f;
+        }
+
+        protected override string GetTitle() => "Slow Pour";
+        protected override string GetDescription() => "Like running through molasses.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Slow", amount = "25%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Duration", amount = "3s", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-10%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.ColdBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/SlowTide.cs
+++ b/src/Cards/SlowTide.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class SlowTide : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.AddComponent<SlowOnHitSpawner>();
+            s.slowPercent = 0.5f;
+            s.slowDuration = 4f;
+            gun.damage *= 0.8f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var s = player.gameObject.GetComponent<SlowOnHitSpawner>();
+            if (s != null) Object.Destroy(s);
+            gun.damage /= 0.8f;
+        }
+
+        protected override string GetTitle() => "Slow Tide";
+        protected override string GetDescription() => "The world moves at your pace now.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Slow", amount = "50%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Duration", amount = "4s", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-20%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.ColdBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/SnakeRain.cs
+++ b/src/Cards/SnakeRain.cs
@@ -1,0 +1,48 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class SnakeRain : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var e = player.gameObject.AddComponent<SnakeRainEffect>();
+            e.snakeCount = 3;
+            e.snakeDamage = 15f;
+            e.snakeSpeed = 8f;
+            e.snakeLifetime = 4f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var e = player.gameObject.GetComponent<SnakeRainEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Snake Rain";
+        protected override string GetDescription() => "Get hit, release the snakes.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "3 Homing Snakes When Hit",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.NatureBrown;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/SpeedDemon.cs
+++ b/src/Cards/SpeedDemon.cs
@@ -1,0 +1,59 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class SpeedDemonStorage : MonoBehaviour
+    {
+        public float origMoveSpeed;
+        public float origDamage;
+    }
+
+    public class SpeedDemon : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.AddComponent<SpeedDemonStorage>();
+            store.origMoveSpeed = characterStats.movementSpeed;
+            store.origDamage = gun.damage;
+
+            gun.damage *= (1f + characterStats.movementSpeed * 0.5f);
+            characterStats.movementSpeed *= 0.5f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var store = player.gameObject.GetComponent<SpeedDemonStorage>();
+            if (store != null)
+            {
+                gun.damage = store.origDamage;
+                characterStats.movementSpeed = store.origMoveSpeed;
+                Object.Destroy(store);
+            }
+        }
+
+        protected override string GetTitle() => "Speed Demon";
+        protected override string GetDescription() => "Trade agility for firepower. Or is it the other way around?";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat
+                {
+                    positive = true,
+                    stat = "Effect",
+                    amount = "Swap Speed for Damage",
+                    simepleAmount = CardInfoStat.SimpleAmount.notAssigned
+                }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Uncommon;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.DestructiveRed;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/SquidInk.cs
+++ b/src/Cards/SquidInk.cs
@@ -1,0 +1,54 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class SquidInk : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.damage *= 0.75f;
+
+            var e = player.gameObject.AddComponent<HomingSquidEffect>();
+            e.squidCount = 2;
+            e.squidDamage = 15f;
+            e.squidSpeed = 8f;
+            e.squidLifetime = 6f;
+            e.inkRadius = 3f;
+            e.inkDuration = 3f;
+            e.inkSlowAmount = 0.5f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.damage /= 0.75f;
+
+            var e = player.gameObject.GetComponent<HomingSquidEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Squid Ink";
+        protected override string GetDescription() => "Swim, little squids. SWIM.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Homing Squids", amount = "2 per shot", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Ink Cloud", amount = "Slow enemies", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Damage", amount = "-25%", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/StatLeech.cs
+++ b/src/Cards/StatLeech.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    public class StatLeech : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+            cardInfo.allowMultiple = false;
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var others = PlayerManager.instance.players.FindAll(p => p != player && !p.data.dead);
+
+            foreach (var other in others)
+            {
+                var otherGun = other.GetComponentInChildren<Gun>();
+                if (otherGun == null) continue;
+
+                // Leech 15% of each stat that's higher than yours
+                if (otherGun.damage > gun.damage)
+                {
+                    float leech = otherGun.damage * 0.15f;
+                    otherGun.damage -= leech;
+                    gun.damage += leech;
+                }
+
+                if (other.data.maxHealth > data.maxHealth)
+                {
+                    float leech = other.data.maxHealth * 0.15f;
+                    other.data.maxHealth -= leech;
+                    data.maxHealth += leech;
+                }
+            }
+
+            // Replace self with inert placeholder to prevent re-triggering on swap
+            var ph = CardRegistry.Get("Stat Leech Used");
+            if (ph != null)
+            {
+                for (int j = data.currentCards.Count - 1; j >= 0; j--)
+                {
+                    if (data.currentCards[j].cardName == "Stat Leech")
+                    {
+                        data.currentCards[j] = ph;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Stat Leech";
+        protected override string GetDescription() => "Siphon the strong. Hope they don't notice.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Leech 15%", amount = "Better Stats From Others", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/StatLeechPlaceholder.cs
+++ b/src/Cards/StatLeechPlaceholder.cs
@@ -1,0 +1,42 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using RarityLib.Utils;
+
+namespace SWIP.Cards
+{
+    /// <summary>
+    /// Inert placeholder card that replaces "Stat Leech" after execution,
+    /// preventing it from re-triggering on swap.
+    /// </summary>
+    public class StatLeechPlaceholder : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            // Intentionally empty — this card does nothing
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+        }
+
+        protected override string GetTitle() => "Stat Leech Used";
+        protected override string GetDescription() => "You leeched what you could.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Leeched", amount = "Stats", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => RarityUtils.GetRarity("Epic");
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/TortillaShield.cs
+++ b/src/Cards/TortillaShield.cs
@@ -1,0 +1,43 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class TortillaShield : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var e = player.gameObject.AddComponent<TortillaWrapEffect>();
+            e.wrapDuration = 3f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            var e = player.gameObject.GetComponent<TortillaWrapEffect>();
+            if (e != null) Object.Destroy(e);
+        }
+
+        protected override string GetTitle() => "Tortilla Shield";
+        protected override string GetDescription() => "Wrap yourself in carbs. Become invincible.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Invulnerable Wrap", amount = "On Block", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Duration", amount = "3s", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = false, stat = "Immobile", amount = "During Wrap", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.DefensiveBlue;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/VortexBounce.cs
+++ b/src/Cards/VortexBounce.cs
@@ -1,0 +1,47 @@
+using UnboundLib.Cards;
+using UnityEngine;
+using SWIP.Effects;
+
+namespace SWIP.Cards
+{
+    public class VortexBounce : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
+        {
+        }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects += 2;
+
+            var s = player.gameObject.AddComponent<VortexBounceSpawner>();
+            s.pullRadius = 5f;
+            s.pullForce = 800f;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.reflects -= 2;
+
+            var s = player.gameObject.GetComponent<VortexBounceSpawner>();
+            if (s != null) Object.Destroy(s);
+        }
+
+        protected override string GetTitle() => "Vortex Bounce";
+        protected override string GetDescription() => "Come closer. CLOSER.";
+
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Pull Enemies", amount = "On Bounce", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bounces", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Rare;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.EvilPurple;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Cards/WideSpread.cs
+++ b/src/Cards/WideSpread.cs
@@ -1,0 +1,37 @@
+using UnboundLib.Cards;
+using UnityEngine;
+
+namespace SWIP.Cards
+{
+    public class WideSpread : CustomCard
+    {
+        public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block) { }
+
+        public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.spread += 0.5f;
+            gun.numberOfProjectiles += 2;
+        }
+
+        public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
+        {
+            gun.spread -= 0.5f;
+            gun.numberOfProjectiles -= 2;
+        }
+
+        protected override string GetTitle() => "Wide Spread";
+        protected override string GetDescription() => "Shotgun diplomacy.";
+        protected override CardInfoStat[] GetStats()
+        {
+            return new CardInfoStat[]
+            {
+                new CardInfoStat { positive = true, stat = "Spread", amount = "+0.5", simepleAmount = CardInfoStat.SimpleAmount.notAssigned },
+                new CardInfoStat { positive = true, stat = "Bullets", amount = "+2", simepleAmount = CardInfoStat.SimpleAmount.notAssigned }
+            };
+        }
+        protected override CardInfo.Rarity GetRarity() => CardInfo.Rarity.Common;
+        protected override GameObject GetCardArt() => null;
+        protected override CardThemeColor.CardThemeColorType GetTheme() => CardThemeColor.CardThemeColorType.FirepowerYellow;
+        public override string GetModName() => "SWIP";
+    }
+}

--- a/src/Effects/BounceRandomSizeEffect.cs
+++ b/src/Effects/BounceRandomSizeEffect.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class BounceRandomSizeEffect : MonoBehaviour
+    {
+        public float speedMultPerBounce = 1.15f;
+
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private Rigidbody2D rb;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            rb = GetComponent<Rigidbody2D>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+
+                        float scale = Random.Range(0.5f, 2.0f);
+                        transform.localScale = Vector3.one * scale;
+
+                        if (rb != null)
+                        {
+                            rb.velocity *= speedMultPerBounce;
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class BounceRandomSizeSpawner : ProjectileEffectSpawner
+    {
+        public float speedMultPerBounce = 1.15f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<BounceRandomSizeEffect>();
+            effect.speedMultPerBounce = speedMultPerBounce;
+        }
+    }
+}

--- a/src/Effects/ChaosRicochetEffect.cs
+++ b/src/Effects/ChaosRicochetEffect.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class ChaosRicochetEffect : MonoBehaviour
+    {
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private Rigidbody2D rb;
+        private ProjectileHit projectileHit;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            rb = GetComponent<Rigidbody2D>();
+            projectileHit = GetComponent<ProjectileHit>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+
+                        if (projectileHit != null && rb != null)
+                        {
+                            float oldDmg = projectileHit.damage;
+                            float oldSpeed = rb.velocity.magnitude;
+                            projectileHit.damage = oldSpeed;
+                            rb.velocity = rb.velocity.normalized * oldDmg;
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class ChaosRicochetSpawner : ProjectileEffectSpawner
+    {
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            projectile.AddComponent<ChaosRicochetEffect>();
+        }
+    }
+}

--- a/src/Effects/ClipDumpEffect.cs
+++ b/src/Effects/ClipDumpEffect.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class ClipDumpEffect : MonoBehaviour
+    {
+        public float speedMultiplier = 0.05f;
+
+        private Gun gun;
+        private Player player;
+        private bool hooked;
+        private float originalAttackSpeed;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            TryHookGun();
+        }
+
+        void Update()
+        {
+            if (!hooked)
+            {
+                TryHookGun();
+            }
+        }
+
+        private void TryHookGun()
+        {
+            if (player == null) return;
+
+            Gun foundGun = null;
+            var holding = player.GetComponent<Holding>();
+            if (holding != null && holding.holdable != null)
+            {
+                foundGun = holding.holdable.GetComponent<Gun>();
+            }
+            if (foundGun == null)
+            {
+                foundGun = player.GetComponentInChildren<Gun>();
+            }
+
+            if (foundGun != null)
+            {
+                gun = foundGun;
+                originalAttackSpeed = gun.attackSpeed;
+                gun.attackSpeed *= speedMultiplier;
+                hooked = true;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (gun != null)
+            {
+                gun.attackSpeed = originalAttackSpeed;
+            }
+        }
+    }
+}

--- a/src/Effects/FeatherfallBounceEffect.cs
+++ b/src/Effects/FeatherfallBounceEffect.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class FeatherfallBounceEffect : MonoBehaviour
+    {
+        public float gravityReductionPerBounce = 0.3f;
+
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private Rigidbody2D rb;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            rb = GetComponent<Rigidbody2D>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+                        if (rb != null)
+                        {
+                            rb.gravityScale = Mathf.Max(0f, rb.gravityScale - gravityReductionPerBounce);
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class FeatherfallBounceSpawner : ProjectileEffectSpawner
+    {
+        public float gravityReductionPerBounce = 0.3f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<FeatherfallBounceEffect>();
+            effect.gravityReductionPerBounce = gravityReductionPerBounce;
+        }
+    }
+}

--- a/src/Effects/HomingBirdEffect.cs
+++ b/src/Effects/HomingBirdEffect.cs
@@ -1,0 +1,235 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class HomingBirdEffect : MonoBehaviour
+    {
+        public int birdCount = 2;
+        public float birdDamage = 20f;
+        public float birdSpeed = 12f;
+        public float birdLifetime = 5f;
+
+        private Gun gun;
+        private Player player;
+        private bool hooked;
+        private int lastShotFrame = -1;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            TryHookGun();
+        }
+
+        void Update()
+        {
+            if (!hooked)
+            {
+                TryHookGun();
+            }
+        }
+
+        private void TryHookGun()
+        {
+            if (player == null) return;
+
+            Gun foundGun = null;
+            var holding = player.GetComponent<Holding>();
+            if (holding != null && holding.holdable != null)
+            {
+                foundGun = holding.holdable.GetComponent<Gun>();
+            }
+            if (foundGun == null)
+            {
+                foundGun = player.GetComponentInChildren<Gun>();
+            }
+
+            if (foundGun != null)
+            {
+                gun = foundGun;
+                gun.ShootPojectileAction += OnShoot;
+                hooked = true;
+            }
+        }
+
+        private void OnShoot(GameObject projectile)
+        {
+            if (player == null) return;
+
+            // Only spawn birds once per shot, not once per bullet
+            int frame = Time.frameCount;
+            if (frame == lastShotFrame) return;
+            lastShotFrame = frame;
+
+            for (int i = 0; i < birdCount; i++)
+            {
+                var birdObj = new GameObject("Bird");
+                birdObj.transform.position = player.transform.position + new Vector3(
+                    Random.Range(-0.5f, 0.5f),
+                    Random.Range(1f, 2f),
+                    0f
+                );
+
+                var rb = birdObj.AddComponent<Rigidbody2D>();
+                rb.gravityScale = 0f;
+                rb.mass = 0.05f;
+                rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+                var col = birdObj.AddComponent<CircleCollider2D>();
+                col.radius = 0.15f;
+                col.isTrigger = true;
+
+                // Bright red body
+                var lr = birdObj.AddComponent<LineRenderer>();
+                lr.useWorldSpace = false;
+                lr.startWidth = 0.14f;
+                lr.endWidth = 0.06f;
+                lr.positionCount = 2;
+                lr.SetPosition(0, Vector3.zero);
+                lr.SetPosition(1, new Vector3(0f, -0.25f, 0f));
+                lr.material = new Material(Shader.Find("Sprites/Default"));
+                lr.startColor = new Color(1f, 0.2f, 0.1f, 1f);
+                lr.endColor = new Color(0.9f, 0.4f, 0.2f, 0.9f);
+                lr.sortingOrder = 5;
+
+                // Small trail
+                var trailObj = new GameObject("BirdTrail");
+                trailObj.transform.SetParent(birdObj.transform);
+                trailObj.transform.localPosition = Vector3.zero;
+                var trail = trailObj.AddComponent<TrailRenderer>();
+                trail.time = 0.3f;
+                trail.startWidth = 0.1f;
+                trail.endWidth = 0f;
+                trail.material = new Material(Shader.Find("Sprites/Default"));
+                trail.startColor = new Color(1f, 0.3f, 0.1f, 0.6f);
+                trail.endColor = new Color(1f, 0.5f, 0.2f, 0f);
+                trail.sortingOrder = 4;
+                trail.minVertexDistance = 0.1f;
+
+                var homing = birdObj.AddComponent<BirdHomingBehaviour>();
+                homing.owner = player;
+                homing.speed = birdSpeed;
+                homing.damage = birdDamage;
+                homing.lifetime = birdLifetime;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (gun != null)
+            {
+                gun.ShootPojectileAction -= OnShoot;
+            }
+        }
+    }
+
+    public class BirdHomingBehaviour : MonoBehaviour
+    {
+        public Player owner;
+        public float speed = 12f;
+        public float damage = 20f;
+        public float lifetime = 5f;
+        public float steerStrength = 10f;
+        public float hitRadius = 1.5f;
+        public float swoopAmplitude = 1.5f;
+        public float swoopFrequency = 3f;
+
+        private float timer;
+        private bool hit;
+        private Rigidbody2D rb;
+        private LineRenderer lr;
+
+        void Start()
+        {
+            timer = lifetime;
+            rb = GetComponent<Rigidbody2D>();
+            lr = GetComponent<LineRenderer>();
+
+            if (rb != null)
+            {
+                rb.velocity = Vector2.up * speed * 0.5f;
+            }
+        }
+
+        void FixedUpdate()
+        {
+            timer -= Time.fixedDeltaTime;
+            if (timer <= 0f)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Player target = FindClosestEnemy();
+            if (target == null || rb == null) return;
+
+            Vector2 toTarget = ((Vector2)target.transform.position - (Vector2)transform.position).normalized;
+
+            // Swooping arc: sine wave vertical oscillation
+            float swoop = Mathf.Sin(Time.time * swoopFrequency) * swoopAmplitude;
+            Vector2 perpendicular = new Vector2(-toTarget.y, toTarget.x);
+            Vector2 desired = toTarget + perpendicular * swoop * 0.2f;
+
+            rb.velocity = Vector2.Lerp(rb.velocity.normalized, desired.normalized, Time.fixedDeltaTime * steerStrength) * speed;
+
+            // Orient the visual along velocity
+            if (lr != null && rb.velocity.sqrMagnitude > 0.1f)
+            {
+                Vector3 tail = ((Vector3)(-rb.velocity.normalized)) * 0.3f;
+                lr.SetPosition(1, tail);
+            }
+
+            // Proximity hit
+            float dist = Vector2.Distance(transform.position, target.transform.position);
+            if (dist < hitRadius)
+            {
+                HitTarget(target);
+            }
+        }
+
+        void OnTriggerEnter2D(Collider2D other)
+        {
+            // Ignore other birds
+            if (other.GetComponent<BirdHomingBehaviour>() != null) return;
+
+            // Ignore owner's team
+            var player = other.GetComponentInParent<Player>();
+            if (player != null && owner != null && player.teamID == owner.teamID) return;
+
+            if (player != null) HitTarget(player);
+        }
+
+        private void HitTarget(Player target)
+        {
+            if (hit) return;
+            hit = true;
+
+            if (target != null && !target.data.dead)
+            {
+                target.data.healthHandler.TakeDamage(Vector2.up * damage, transform.position);
+            }
+
+            Destroy(gameObject);
+        }
+
+        private Player FindClosestEnemy()
+        {
+            Player closest = null;
+            float closestDist = float.MaxValue;
+
+            foreach (var p in PlayerManager.instance.players)
+            {
+                if (p == owner) continue;
+                if (p.data.dead) continue;
+                if (owner != null && p.teamID == owner.teamID) continue;
+
+                float dist = Vector2.Distance(transform.position, p.transform.position);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closest = p;
+                }
+            }
+            return closest;
+        }
+    }
+}

--- a/src/Effects/HomingSquidEffect.cs
+++ b/src/Effects/HomingSquidEffect.cs
@@ -1,0 +1,260 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class HomingSquidEffect : MonoBehaviour
+    {
+        public int squidCount = 2;
+        public float squidDamage = 15f;
+        public float squidSpeed = 8f;
+        public float squidLifetime = 6f;
+        public float inkRadius = 3f;
+        public float inkDuration = 3f;
+        public float inkSlowAmount = 0.5f;
+
+        private Gun gun;
+        private Player player;
+        private bool hooked;
+        private int lastShotFrame = -1;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            TryHookGun();
+        }
+
+        void Update()
+        {
+            if (!hooked)
+            {
+                TryHookGun();
+            }
+        }
+
+        private void TryHookGun()
+        {
+            if (player == null) return;
+
+            Gun foundGun = null;
+            var holding = player.GetComponent<Holding>();
+            if (holding != null && holding.holdable != null)
+            {
+                foundGun = holding.holdable.GetComponent<Gun>();
+            }
+            if (foundGun == null)
+            {
+                foundGun = player.GetComponentInChildren<Gun>();
+            }
+
+            if (foundGun != null)
+            {
+                gun = foundGun;
+                gun.ShootPojectileAction += OnShoot;
+                hooked = true;
+            }
+        }
+
+        private void OnShoot(GameObject projectile)
+        {
+            if (player == null) return;
+
+            // Only spawn squids once per shot, not once per bullet
+            int frame = Time.frameCount;
+            if (frame == lastShotFrame) return;
+            lastShotFrame = frame;
+
+            for (int i = 0; i < squidCount; i++)
+            {
+                var squidObj = new GameObject("Squid");
+                squidObj.transform.position = player.transform.position + new Vector3(
+                    Random.Range(-0.8f, 0.8f),
+                    Random.Range(0.5f, 1.5f),
+                    0f
+                );
+
+                var rb = squidObj.AddComponent<Rigidbody2D>();
+                rb.gravityScale = 0f;
+                rb.mass = 0.08f;
+                rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+                var col = squidObj.AddComponent<CircleCollider2D>();
+                col.radius = 0.15f;
+                col.isTrigger = true;
+
+                // Purple body
+                var lr = squidObj.AddComponent<LineRenderer>();
+                lr.useWorldSpace = false;
+                lr.startWidth = 0.14f;
+                lr.endWidth = 0.08f;
+                lr.positionCount = 2;
+                lr.SetPosition(0, Vector3.zero);
+                lr.SetPosition(1, new Vector3(0f, -0.3f, 0f));
+                lr.material = new Material(Shader.Find("Sprites/Default"));
+                lr.startColor = new Color(0.6f, 0.2f, 0.8f, 1f);
+                lr.endColor = new Color(0.4f, 0.1f, 0.6f, 0.9f);
+                lr.sortingOrder = 5;
+
+                // Dark purple trail
+                var trailObj = new GameObject("SquidTrail");
+                trailObj.transform.SetParent(squidObj.transform);
+                trailObj.transform.localPosition = Vector3.zero;
+                var trail = trailObj.AddComponent<TrailRenderer>();
+                trail.time = 0.4f;
+                trail.startWidth = 0.1f;
+                trail.endWidth = 0f;
+                trail.material = new Material(Shader.Find("Sprites/Default"));
+                trail.startColor = new Color(0.4f, 0.1f, 0.6f, 0.6f);
+                trail.endColor = new Color(0.3f, 0.05f, 0.5f, 0f);
+                trail.sortingOrder = 4;
+                trail.minVertexDistance = 0.1f;
+
+                var homing = squidObj.AddComponent<SquidHomingBehaviour>();
+                homing.owner = player;
+                homing.speed = squidSpeed;
+                homing.damage = squidDamage;
+                homing.lifetime = squidLifetime;
+                homing.inkRadius = inkRadius;
+                homing.inkDuration = inkDuration;
+                homing.inkSlowAmount = inkSlowAmount;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (gun != null)
+            {
+                gun.ShootPojectileAction -= OnShoot;
+            }
+        }
+    }
+
+    public class SquidHomingBehaviour : MonoBehaviour
+    {
+        public Player owner;
+        public float speed = 8f;
+        public float damage = 15f;
+        public float lifetime = 6f;
+        public float steerStrength = 15f;
+        public float hitRadius = 1.5f;
+        public float swimAmplitude = 1.5f;
+        public float swimFrequency = 4f;
+        public float inkRadius = 3f;
+        public float inkDuration = 3f;
+        public float inkSlowAmount = 0.5f;
+
+        private float timer;
+        private bool hit;
+        private Rigidbody2D rb;
+        private LineRenderer lr;
+
+        void Start()
+        {
+            timer = lifetime;
+            rb = GetComponent<Rigidbody2D>();
+            lr = GetComponent<LineRenderer>();
+
+            if (rb != null)
+            {
+                rb.velocity = Random.insideUnitCircle.normalized * speed;
+            }
+        }
+
+        void FixedUpdate()
+        {
+            timer -= Time.fixedDeltaTime;
+            if (timer <= 0f)
+            {
+                SpawnInkCloud();
+                Destroy(gameObject);
+                return;
+            }
+
+            Player target = FindClosestEnemy();
+            if (target == null || rb == null) return;
+
+            Vector2 toTarget = ((Vector2)target.transform.position - (Vector2)transform.position).normalized;
+
+            // Sinusoidal oscillation perpendicular to velocity for swimming motion
+            Vector2 perp = new Vector2(-toTarget.y, toTarget.x);
+            float swim = Mathf.Sin(Time.time * swimFrequency) * swimAmplitude;
+            Vector2 desired = toTarget + perp * swim * 0.25f;
+
+            rb.velocity = Vector2.Lerp(rb.velocity.normalized, desired.normalized, Time.fixedDeltaTime * steerStrength) * speed;
+
+            // Orient the visual along velocity
+            if (lr != null && rb.velocity.sqrMagnitude > 0.1f)
+            {
+                Vector3 tail = ((Vector3)(-rb.velocity.normalized)) * 0.35f;
+                lr.SetPosition(1, tail);
+            }
+
+            // Proximity hit
+            float dist = Vector2.Distance(transform.position, target.transform.position);
+            if (dist < hitRadius)
+            {
+                HitTarget(target);
+            }
+        }
+
+        void OnTriggerEnter2D(Collider2D other)
+        {
+            // Ignore other squids
+            if (other.GetComponent<SquidHomingBehaviour>() != null) return;
+
+            // Ignore owner's team
+            var player = other.GetComponentInParent<Player>();
+            if (player != null && owner != null && player.teamID == owner.teamID) return;
+
+            if (player != null) HitTarget(player);
+        }
+
+        private void HitTarget(Player target)
+        {
+            if (hit) return;
+            hit = true;
+
+            if (target != null && !target.data.dead)
+            {
+                target.data.healthHandler.TakeDamage(Vector2.up * damage, transform.position);
+            }
+
+            SpawnInkCloud();
+            Destroy(gameObject);
+        }
+
+        private void SpawnInkCloud()
+        {
+            var cloudObj = new GameObject("InkCloud");
+            cloudObj.transform.position = transform.position;
+            var zone = cloudObj.AddComponent<ZoneBehaviour>();
+            zone.radius = inkRadius;
+            zone.duration = inkDuration;
+            zone.slowAmount = inkSlowAmount;
+            zone.damagePerSecond = 0f;
+            zone.outerColor = new Color(0.3f, 0.1f, 0.4f, 0.5f);
+            zone.innerColor = new Color(0.2f, 0.05f, 0.3f, 0.35f);
+            zone.owner = owner;
+        }
+
+        private Player FindClosestEnemy()
+        {
+            Player closest = null;
+            float closestDist = float.MaxValue;
+
+            foreach (var p in PlayerManager.instance.players)
+            {
+                if (p == owner) continue;
+                if (p.data.dead) continue;
+                if (owner != null && p.teamID == owner.teamID) continue;
+
+                float dist = Vector2.Distance(transform.position, p.transform.position);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closest = p;
+                }
+            }
+            return closest;
+        }
+    }
+}

--- a/src/Effects/IceRicochetEffect.cs
+++ b/src/Effects/IceRicochetEffect.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class IceRicochetEffect : MonoBehaviour
+    {
+        public float freezeRadius = 4f;
+        public float slowPercent = 0.4f;
+        public float freezeDuration = 2f;
+
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private ProjectileHit projectileHit;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            projectileHit = GetComponent<ProjectileHit>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+
+                        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, freezeRadius);
+                        foreach (var hit in hits)
+                        {
+                            Player player = hit.GetComponent<Player>();
+                            if (player == null) continue;
+                            if (player.data.dead) continue;
+                            if (projectileHit != null && projectileHit.ownPlayer != null &&
+                                player.teamID == projectileHit.ownPlayer.teamID) continue;
+
+                            var freeze = player.gameObject.AddComponent<FreezeDamageEffect>();
+                            freeze.slowPercent = slowPercent;
+                            freeze.duration = freezeDuration;
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class IceRicochetSpawner : ProjectileEffectSpawner
+    {
+        public float freezeRadius = 4f;
+        public float slowPercent = 0.4f;
+        public float freezeDuration = 2f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<IceRicochetEffect>();
+            effect.freezeRadius = freezeRadius;
+            effect.slowPercent = slowPercent;
+            effect.freezeDuration = freezeDuration;
+        }
+    }
+}

--- a/src/Effects/LemonDropEffect.cs
+++ b/src/Effects/LemonDropEffect.cs
@@ -1,0 +1,90 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class LemonDropEffect : MonoBehaviour
+    {
+        public float blindRadius = 3f;
+        public float blindDuration = 2f;
+        public float slowAmount = 0.6f;
+
+        private ProjectileHit projectileHit;
+        private Player owner;
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+
+        void Start()
+        {
+            projectileHit = GetComponentInParent<ProjectileHit>();
+            if (projectileHit == null) projectileHit = GetComponent<ProjectileHit>();
+            if (projectileHit != null)
+            {
+                owner = projectileHit.ownPlayer;
+                projectileHit.AddHitAction(SpawnLemon);
+            }
+            lastPosition = transform.position;
+        }
+
+        void FixedUpdate()
+        {
+            if (bounceCooldown > 0f)
+            {
+                bounceCooldown -= Time.fixedDeltaTime;
+            }
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.5f)
+                    {
+                        bounceCooldown = 0.15f;
+                        SpawnLemon();
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+
+        private void SpawnLemon()
+        {
+            var zoneObj = new GameObject("LemonZone");
+            zoneObj.transform.position = transform.position;
+            var zone = zoneObj.AddComponent<ZoneBehaviour>();
+            zone.radius = blindRadius;
+            zone.duration = blindDuration;
+            zone.slowAmount = slowAmount;
+            zone.damagePerSecond = 0f;
+            zone.outerColor = new Color(1f, 1f, 0.2f, 0.5f);
+            zone.innerColor = new Color(1f, 0.95f, 0.4f, 0.35f);
+            zone.owner = owner;
+        }
+    }
+
+    public class LemonDropSpawner : ProjectileEffectSpawner
+    {
+        public float blindRadius = 3f;
+        public float blindDuration = 2f;
+        public float slowAmount = 0.6f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<LemonDropEffect>();
+            effect.blindRadius = blindRadius;
+            effect.blindDuration = blindDuration;
+            effect.slowAmount = slowAmount;
+        }
+    }
+}

--- a/src/Effects/NachosOnBlockEffect.cs
+++ b/src/Effects/NachosOnBlockEffect.cs
@@ -1,0 +1,129 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class NachosOnBlockEffect : MonoBehaviour
+    {
+        public int nachoCount = 5;
+        public float nachoDamage = 10f;
+        public float nachoHeal = 5f;
+        public float nachoSpeed = 8f;
+        public float nachoLifetime = 3f;
+
+        private Player player;
+        private Block block;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            if (player != null)
+            {
+                block = player.GetComponent<Block>();
+                if (block != null)
+                {
+                    block.BlockAction += OnBlock;
+                }
+            }
+        }
+
+        private void OnBlock(BlockTrigger.BlockTriggerType triggerType)
+        {
+            if (player == null) return;
+
+            for (int i = 0; i < nachoCount; i++)
+            {
+                float angle = (360f / nachoCount) * i;
+                Vector2 dir = Quaternion.Euler(0, 0, angle) * Vector2.right;
+
+                var nachoObj = new GameObject("Nacho");
+                nachoObj.transform.position = player.transform.position;
+
+                var rb = nachoObj.AddComponent<Rigidbody2D>();
+                rb.gravityScale = 0.5f;
+                rb.velocity = dir * nachoSpeed;
+                rb.mass = 0.1f;
+
+                var col = nachoObj.AddComponent<CircleCollider2D>();
+                col.radius = 0.15f;
+                col.isTrigger = true;
+
+                // Yellow triangle visual
+                var lr = nachoObj.AddComponent<LineRenderer>();
+                lr.useWorldSpace = false;
+                lr.startWidth = 0.08f;
+                lr.endWidth = 0.08f;
+                lr.positionCount = 4;
+                lr.SetPosition(0, new Vector3(-0.1f, -0.08f, 0f));
+                lr.SetPosition(1, new Vector3(0.1f, -0.08f, 0f));
+                lr.SetPosition(2, new Vector3(0f, 0.12f, 0f));
+                lr.SetPosition(3, new Vector3(-0.1f, -0.08f, 0f));
+                lr.material = new Material(Shader.Find("Sprites/Default"));
+                lr.startColor = new Color(1f, 0.85f, 0.2f, 1f);
+                lr.endColor = new Color(0.9f, 0.7f, 0.1f, 1f);
+                lr.sortingOrder = 5;
+                lr.loop = true;
+
+                var nacho = nachoObj.AddComponent<NachoProjectile>();
+                nacho.owner = player;
+                nacho.damage = nachoDamage;
+                nacho.healAmount = nachoHeal;
+                nacho.lifetime = nachoLifetime;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (block != null)
+            {
+                block.BlockAction -= OnBlock;
+            }
+        }
+    }
+
+    public class NachoProjectile : MonoBehaviour
+    {
+        public Player owner;
+        public float damage = 10f;
+        public float healAmount = 5f;
+        public float lifetime = 3f;
+
+        private float timer;
+        private bool used;
+
+        void Start()
+        {
+            timer = lifetime;
+        }
+
+        void Update()
+        {
+            timer -= Time.deltaTime;
+            if (timer <= 0f)
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        void OnTriggerEnter2D(Collider2D other)
+        {
+            if (used) return;
+
+            var player = other.GetComponentInParent<Player>();
+            if (player == null || player.data.dead) return;
+
+            if (owner != null && player.teamID == owner.teamID)
+            {
+                // Heal ally
+                player.data.healthHandler.Heal(healAmount);
+            }
+            else
+            {
+                // Damage enemy
+                player.data.healthHandler.TakeDamage(Vector2.up * damage, transform.position);
+            }
+
+            used = true;
+            Destroy(gameObject);
+        }
+    }
+}

--- a/src/Effects/RadialShotEffect.cs
+++ b/src/Effects/RadialShotEffect.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class RadialShotEffect : MonoBehaviour
+    {
+        private Gun gun;
+        private Player player;
+        private bool hooked;
+        private int lastShotFrame = -1;
+        private int projectileIndex = 0;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            TryHookGun();
+        }
+
+        void Update()
+        {
+            if (!hooked)
+            {
+                TryHookGun();
+            }
+        }
+
+        private void TryHookGun()
+        {
+            if (player == null) return;
+
+            Gun foundGun = null;
+            var holding = player.GetComponent<Holding>();
+            if (holding != null && holding.holdable != null)
+            {
+                foundGun = holding.holdable.GetComponent<Gun>();
+            }
+            if (foundGun == null)
+            {
+                foundGun = player.GetComponentInChildren<Gun>();
+            }
+
+            if (foundGun != null)
+            {
+                gun = foundGun;
+                gun.ShootPojectileAction += OnShoot;
+                hooked = true;
+            }
+        }
+
+        private void OnShoot(GameObject projectile)
+        {
+            if (player == null || gun == null) return;
+
+            int frame = Time.frameCount;
+            if (frame != lastShotFrame)
+            {
+                lastShotFrame = frame;
+                projectileIndex = 0;
+            }
+
+            int totalBullets = Mathf.Max(1, gun.numberOfProjectiles);
+            float angle = (360f / totalBullets) * projectileIndex;
+            projectileIndex++;
+
+            // Rotate the projectile's velocity
+            var mt = projectile.GetComponent<MoveTransform>();
+            if (mt != null)
+            {
+                mt.velocity = Quaternion.Euler(0, 0, angle) * mt.velocity;
+            }
+            var rb = projectile.GetComponent<Rigidbody2D>();
+            if (rb != null)
+            {
+                rb.velocity = Quaternion.Euler(0, 0, angle) * rb.velocity;
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (gun != null)
+            {
+                gun.ShootPojectileAction -= OnShoot;
+            }
+        }
+    }
+}

--- a/src/Effects/ScorchingBounceEffect.cs
+++ b/src/Effects/ScorchingBounceEffect.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class ScorchingBounceEffect : MonoBehaviour
+    {
+        public float burnRadius = 4f;
+        public float baseBurnDps = 5f;
+        public float burnDuration = 2f;
+        public float escalation = 1.5f;
+
+        private int bounceCount;
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private ProjectileHit projectileHit;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            projectileHit = GetComponent<ProjectileHit>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+                        bounceCount++;
+
+                        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, burnRadius);
+                        foreach (var hit in hits)
+                        {
+                            Player player = hit.GetComponent<Player>();
+                            if (player == null) continue;
+                            if (player.data.dead) continue;
+                            if (projectileHit != null && projectileHit.ownPlayer != null &&
+                                player.teamID == projectileHit.ownPlayer.teamID) continue;
+
+                            var burn = player.gameObject.AddComponent<BurnDamageEffect>();
+                            burn.damagePerSecond = baseBurnDps * Mathf.Pow(escalation, bounceCount - 1);
+                            burn.duration = burnDuration;
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class ScorchingBounceSpawner : ProjectileEffectSpawner
+    {
+        public float burnRadius = 4f;
+        public float baseBurnDps = 5f;
+        public float burnDuration = 2f;
+        public float escalation = 1.5f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<ScorchingBounceEffect>();
+            effect.burnRadius = burnRadius;
+            effect.baseBurnDps = baseBurnDps;
+            effect.burnDuration = burnDuration;
+            effect.escalation = escalation;
+        }
+    }
+}

--- a/src/Effects/ScreenBounceEffect.cs
+++ b/src/Effects/ScreenBounceEffect.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class ScreenBounceEffect : MonoBehaviour
+    {
+        private void FixedUpdate()
+        {
+            Camera cam = Camera.main;
+            if (cam == null) return;
+
+            Vector3 worldPos = transform.position;
+            Vector3 vp = cam.WorldToViewportPoint(worldPos);
+            bool reflected = false;
+
+            Rigidbody2D rb = GetComponent<Rigidbody2D>();
+            MoveTransform mt = GetComponent<MoveTransform>();
+
+            if (vp.x < 0f)
+            {
+                vp.x = 0f;
+                if (rb != null) rb.velocity = new Vector2(Mathf.Abs(rb.velocity.x), rb.velocity.y);
+                if (mt != null) mt.velocity = new Vector3(Mathf.Abs(mt.velocity.x), mt.velocity.y, mt.velocity.z);
+                reflected = true;
+            }
+            else if (vp.x > 1f)
+            {
+                vp.x = 1f;
+                if (rb != null) rb.velocity = new Vector2(-Mathf.Abs(rb.velocity.x), rb.velocity.y);
+                if (mt != null) mt.velocity = new Vector3(-Mathf.Abs(mt.velocity.x), mt.velocity.y, mt.velocity.z);
+                reflected = true;
+            }
+
+            if (vp.y < 0f)
+            {
+                vp.y = 0f;
+                if (rb != null) rb.velocity = new Vector2(rb.velocity.x, Mathf.Abs(rb.velocity.y));
+                if (mt != null) mt.velocity = new Vector3(mt.velocity.x, Mathf.Abs(mt.velocity.y), mt.velocity.z);
+                reflected = true;
+            }
+            else if (vp.y > 1f)
+            {
+                vp.y = 1f;
+                if (rb != null) rb.velocity = new Vector2(rb.velocity.x, -Mathf.Abs(rb.velocity.y));
+                if (mt != null) mt.velocity = new Vector3(mt.velocity.x, -Mathf.Abs(mt.velocity.y), mt.velocity.z);
+                reflected = true;
+            }
+
+            if (reflected)
+            {
+                Vector3 clampedWorld = cam.ViewportToWorldPoint(vp);
+                clampedWorld.z = worldPos.z;
+                transform.position = clampedWorld;
+            }
+        }
+    }
+
+    public class ScreenBounceSpawner : ProjectileEffectSpawner
+    {
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            projectile.AddComponent<ScreenBounceEffect>();
+        }
+    }
+}

--- a/src/Effects/ShockwaveBounceEffect.cs
+++ b/src/Effects/ShockwaveBounceEffect.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class ShockwaveBounceEffect : MonoBehaviour
+    {
+        public float pushRadius = 5f;
+        public float pushForce = 1200f;
+
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private ProjectileHit projectileHit;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            projectileHit = GetComponent<ProjectileHit>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+
+                        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, pushRadius);
+                        foreach (var hit in hits)
+                        {
+                            Player player = hit.GetComponent<Player>();
+                            if (player == null) continue;
+                            if (player.data.dead) continue;
+                            if (projectileHit != null && projectileHit.ownPlayer != null &&
+                                player.teamID == projectileHit.ownPlayer.teamID) continue;
+
+                            Rigidbody2D playerRb = player.GetComponent<Rigidbody2D>();
+                            if (playerRb != null)
+                            {
+                                Vector2 dir = ((Vector2)player.transform.position - (Vector2)transform.position).normalized;
+                                playerRb.AddForce(dir * pushForce);
+                            }
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class ShockwaveBounceSpawner : ProjectileEffectSpawner
+    {
+        public float pushRadius = 5f;
+        public float pushForce = 1200f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<ShockwaveBounceEffect>();
+            effect.pushRadius = pushRadius;
+            effect.pushForce = pushForce;
+        }
+    }
+}

--- a/src/Effects/SlowOnHitEffect.cs
+++ b/src/Effects/SlowOnHitEffect.cs
@@ -1,0 +1,154 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class SlowDebuffEffect : MonoBehaviour
+    {
+        public float slowPercent = 0.3f;
+        public float duration = 2f;
+
+        private float timer;
+        private Rigidbody2D rb;
+        private LineRenderer visual;
+        private float flickerTimer;
+
+        void Start()
+        {
+            timer = duration;
+            var player = GetComponent<Player>();
+            if (player != null)
+            {
+                rb = player.GetComponent<Rigidbody2D>();
+            }
+            CreateVisual();
+        }
+
+        private void CreateVisual()
+        {
+            var visualObj = new GameObject("SlowVisual");
+            visualObj.transform.SetParent(transform);
+            visualObj.transform.localPosition = Vector3.zero;
+
+            visual = visualObj.AddComponent<LineRenderer>();
+            visual.useWorldSpace = false;
+            visual.startWidth = 0.1f;
+            visual.endWidth = 0.1f;
+            visual.loop = true;
+            visual.material = new Material(Shader.Find("Sprites/Default"));
+            visual.startColor = new Color(0.4f, 1f, 0.6f, 0.6f);
+            visual.endColor = new Color(0.3f, 0.9f, 0.5f, 0.6f);
+
+            int segments = 8;
+            visual.positionCount = segments;
+            UpdateShape(1f);
+        }
+
+        private void UpdateShape(float scale)
+        {
+            if (visual == null) return;
+            int segments = visual.positionCount;
+            float baseRadius = 1.2f * scale;
+            for (int i = 0; i < segments; i++)
+            {
+                float angle = (float)i / segments * Mathf.PI * 2f;
+                float r = baseRadius * (1f + Mathf.Sin(angle * 4f + flickerTimer * 3f) * 0.05f);
+                visual.SetPosition(i, new Vector3(
+                    Mathf.Cos(angle) * r,
+                    Mathf.Sin(angle) * r,
+                    0f
+                ));
+            }
+        }
+
+        void FixedUpdate()
+        {
+            if (rb == null)
+            {
+                CleanupVisual();
+                Destroy(this);
+                return;
+            }
+
+            timer -= Time.fixedDeltaTime;
+            if (timer <= 0f)
+            {
+                CleanupVisual();
+                Destroy(this);
+                return;
+            }
+
+            flickerTimer += Time.fixedDeltaTime;
+            UpdateShape(1f);
+
+            if (visual != null)
+            {
+                float alpha = Mathf.Clamp01(timer / duration) * 0.6f;
+                visual.startColor = new Color(0.4f, 1f, 0.6f, alpha);
+                visual.endColor = new Color(0.3f, 0.9f, 0.5f, alpha);
+            }
+
+            rb.velocity *= (1f - slowPercent * Time.fixedDeltaTime);
+        }
+
+        private void CleanupVisual()
+        {
+            if (visual != null)
+            {
+                Destroy(visual.gameObject);
+            }
+        }
+
+        void OnDestroy()
+        {
+            CleanupVisual();
+        }
+    }
+
+    public class SlowOnHitEffect : MonoBehaviour
+    {
+        public float slowPercent = 0.3f;
+        public float slowDuration = 2f;
+
+        private ProjectileHit projectileHit;
+        private Player owner;
+
+        void Start()
+        {
+            projectileHit = GetComponentInParent<ProjectileHit>();
+            if (projectileHit == null) projectileHit = GetComponent<ProjectileHit>();
+            if (projectileHit != null)
+            {
+                owner = projectileHit.ownPlayer;
+                projectileHit.AddHitAction(ApplySlow);
+            }
+        }
+
+        private void ApplySlow()
+        {
+            Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, 3f);
+            foreach (var hit in hits)
+            {
+                var player = hit.GetComponentInParent<Player>();
+                if (player != null && !player.data.dead && player != owner)
+                {
+                    var slow = player.gameObject.AddComponent<SlowDebuffEffect>();
+                    slow.slowPercent = slowPercent;
+                    slow.duration = slowDuration;
+                }
+            }
+        }
+    }
+
+    public class SlowOnHitSpawner : ProjectileEffectSpawner
+    {
+        public float slowPercent = 0.3f;
+        public float slowDuration = 2f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<SlowOnHitEffect>();
+            effect.slowPercent = slowPercent;
+            effect.slowDuration = slowDuration;
+        }
+    }
+}

--- a/src/Effects/SnakeRainEffect.cs
+++ b/src/Effects/SnakeRainEffect.cs
@@ -1,0 +1,199 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class SnakeRainEffect : MonoBehaviour
+    {
+        public int snakeCount = 3;
+        public float snakeDamage = 15f;
+        public float snakeSpeed = 8f;
+        public float snakeLifetime = 4f;
+
+        private Player player;
+        private float lastHealth;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            if (player != null)
+            {
+                lastHealth = player.data.health;
+            }
+        }
+
+        void LateUpdate()
+        {
+            if (player == null || player.data.dead) return;
+
+            float currentHealth = player.data.health;
+            if (currentHealth < lastHealth - 0.1f)
+            {
+                SpawnSnakes();
+            }
+            lastHealth = currentHealth;
+        }
+
+        private void SpawnSnakes()
+        {
+            for (int i = 0; i < snakeCount; i++)
+            {
+                var snakeObj = new GameObject("Snake");
+                snakeObj.transform.position = player.transform.position + new Vector3(
+                    Random.Range(-1f, 1f),
+                    Random.Range(0.5f, 1.5f),
+                    0f
+                );
+
+                var rb = snakeObj.AddComponent<Rigidbody2D>();
+                rb.gravityScale = 0f;
+                rb.mass = 0.05f;
+                rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+
+                var col = snakeObj.AddComponent<CircleCollider2D>();
+                col.radius = 0.1f;
+                col.isTrigger = true;
+
+                // Green trail
+                var trail = snakeObj.AddComponent<TrailRenderer>();
+                trail.time = 0.5f;
+                trail.startWidth = 0.08f;
+                trail.endWidth = 0f;
+                trail.material = new Material(Shader.Find("Sprites/Default"));
+                trail.startColor = new Color(0.2f, 0.9f, 0.2f, 0.8f);
+                trail.endColor = new Color(0.1f, 0.7f, 0.1f, 0f);
+                trail.sortingOrder = 4;
+                trail.minVertexDistance = 0.05f;
+
+                // Small head visual
+                var lr = snakeObj.AddComponent<LineRenderer>();
+                lr.useWorldSpace = false;
+                lr.startWidth = 0.1f;
+                lr.endWidth = 0.06f;
+                lr.positionCount = 2;
+                lr.SetPosition(0, Vector3.zero);
+                lr.SetPosition(1, new Vector3(0f, -0.15f, 0f));
+                lr.material = new Material(Shader.Find("Sprites/Default"));
+                lr.startColor = new Color(0.1f, 0.8f, 0.1f, 1f);
+                lr.endColor = new Color(0.2f, 0.6f, 0.1f, 0.8f);
+                lr.sortingOrder = 5;
+
+                var homing = snakeObj.AddComponent<SnakeHomingBehaviour>();
+                homing.owner = player;
+                homing.speed = snakeSpeed;
+                homing.damage = snakeDamage;
+                homing.lifetime = snakeLifetime;
+            }
+        }
+    }
+
+    public class SnakeHomingBehaviour : MonoBehaviour
+    {
+        public Player owner;
+        public float speed = 8f;
+        public float damage = 15f;
+        public float lifetime = 4f;
+        public float steerStrength = 8f;
+        public float hitRadius = 1.2f;
+        public float waveAmplitude = 2f;
+        public float waveFrequency = 6f;
+
+        private float timer;
+        private bool hit;
+        private Rigidbody2D rb;
+        private LineRenderer lr;
+
+        void Start()
+        {
+            timer = lifetime;
+            rb = GetComponent<Rigidbody2D>();
+            lr = GetComponent<LineRenderer>();
+
+            if (rb != null)
+            {
+                rb.velocity = Random.insideUnitCircle.normalized * speed;
+            }
+        }
+
+        void FixedUpdate()
+        {
+            timer -= Time.fixedDeltaTime;
+            if (timer <= 0f)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Player target = FindClosestEnemy();
+            if (target == null || rb == null) return;
+
+            Vector2 toTarget = ((Vector2)target.transform.position - (Vector2)transform.position).normalized;
+
+            // Sinusoidal perpendicular oscillation for wavy snake movement
+            Vector2 perp = new Vector2(-toTarget.y, toTarget.x);
+            float wave = Mathf.Sin(Time.time * waveFrequency) * waveAmplitude;
+            Vector2 desired = toTarget + perp * wave * 0.3f;
+
+            rb.velocity = Vector2.Lerp(rb.velocity.normalized, desired.normalized, Time.fixedDeltaTime * steerStrength) * speed;
+
+            // Orient the visual along velocity
+            if (lr != null && rb.velocity.sqrMagnitude > 0.1f)
+            {
+                Vector3 tail = ((Vector3)(-rb.velocity.normalized)) * 0.2f;
+                lr.SetPosition(1, tail);
+            }
+
+            // Proximity hit
+            float dist = Vector2.Distance(transform.position, target.transform.position);
+            if (dist < hitRadius)
+            {
+                HitTarget(target);
+            }
+        }
+
+        void OnTriggerEnter2D(Collider2D other)
+        {
+            // Ignore other snakes
+            if (other.GetComponent<SnakeHomingBehaviour>() != null) return;
+
+            // Ignore owner's team
+            var player = other.GetComponentInParent<Player>();
+            if (player != null && owner != null && player.teamID == owner.teamID) return;
+
+            if (player != null) HitTarget(player);
+        }
+
+        private void HitTarget(Player target)
+        {
+            if (hit) return;
+            hit = true;
+
+            if (target != null && !target.data.dead)
+            {
+                target.data.healthHandler.TakeDamage(Vector2.up * damage, transform.position);
+            }
+
+            Destroy(gameObject);
+        }
+
+        private Player FindClosestEnemy()
+        {
+            Player closest = null;
+            float closestDist = float.MaxValue;
+
+            foreach (var p in PlayerManager.instance.players)
+            {
+                if (p == owner) continue;
+                if (p.data.dead) continue;
+                if (owner != null && p.teamID == owner.teamID) continue;
+
+                float dist = Vector2.Distance(transform.position, p.transform.position);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closest = p;
+                }
+            }
+            return closest;
+        }
+    }
+}

--- a/src/Effects/TeleportToBulletEffect.cs
+++ b/src/Effects/TeleportToBulletEffect.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class TeleportToBulletEffect : MonoBehaviour
+    {
+        private ProjectileHit projectileHit;
+        private Player owner;
+
+        void Start()
+        {
+            projectileHit = GetComponentInParent<ProjectileHit>();
+            if (projectileHit == null) projectileHit = GetComponent<ProjectileHit>();
+            if (projectileHit != null)
+            {
+                owner = projectileHit.ownPlayer;
+                projectileHit.AddHitAction(TeleportOwner);
+            }
+        }
+
+        private void TeleportOwner()
+        {
+            if (owner != null && !owner.data.dead)
+            {
+                owner.transform.position = transform.position;
+            }
+        }
+    }
+
+    public class TeleportToBulletSpawner : ProjectileEffectSpawner
+    {
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            projectile.AddComponent<TeleportToBulletEffect>();
+        }
+    }
+}

--- a/src/Effects/TortillaWrapEffect.cs
+++ b/src/Effects/TortillaWrapEffect.cs
@@ -1,0 +1,98 @@
+using System.Collections;
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class TortillaWrapEffect : MonoBehaviour
+    {
+        public float wrapDuration = 3f;
+
+        private Player player;
+        private Block block;
+        private bool wrapping;
+
+        void Start()
+        {
+            player = GetComponentInParent<Player>();
+            if (player != null)
+            {
+                block = player.GetComponent<Block>();
+                if (block != null)
+                {
+                    block.BlockAction += OnBlock;
+                }
+            }
+        }
+
+        private void OnBlock(BlockTrigger.BlockTriggerType triggerType)
+        {
+            if (player == null || wrapping) return;
+            StartCoroutine(WrapCoroutine());
+        }
+
+        private IEnumerator WrapCoroutine()
+        {
+            wrapping = true;
+
+            // Store and disable movement
+            var characterStats = player.data.stats;
+            float origSpeed = characterStats.movementSpeed;
+            characterStats.movementSpeed = 0f;
+
+            // Heal to max for near-invulnerability
+            float maxHp = player.data.maxHealth;
+            player.data.healthHandler.Heal(maxHp);
+
+            // Visual shell — brown circle around player
+            var shellObj = new GameObject("TortillaShell");
+            shellObj.transform.SetParent(player.transform);
+            shellObj.transform.localPosition = Vector3.zero;
+
+            var lr = shellObj.AddComponent<LineRenderer>();
+            lr.useWorldSpace = false;
+            lr.startWidth = 0.15f;
+            lr.endWidth = 0.15f;
+            lr.loop = true;
+            lr.material = new Material(Shader.Find("Sprites/Default"));
+            lr.startColor = new Color(0.8f, 0.65f, 0.3f, 0.8f);
+            lr.endColor = new Color(0.7f, 0.55f, 0.2f, 0.8f);
+            lr.sortingOrder = 10;
+
+            int segments = 16;
+            lr.positionCount = segments;
+            for (int i = 0; i < segments; i++)
+            {
+                float angle = (float)i / segments * Mathf.PI * 2f;
+                lr.SetPosition(i, new Vector3(Mathf.Cos(angle) * 1.5f, Mathf.Sin(angle) * 1.5f, 0f));
+            }
+
+            // Heal continuously during wrap
+            float elapsed = 0f;
+            while (elapsed < wrapDuration)
+            {
+                elapsed += Time.deltaTime;
+                if (player != null && !player.data.dead)
+                {
+                    player.data.healthHandler.Heal(maxHp * Time.deltaTime);
+                }
+                yield return null;
+            }
+
+            // Restore
+            characterStats.movementSpeed = origSpeed;
+            wrapping = false;
+            if (shellObj != null)
+            {
+                Destroy(shellObj);
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (block != null)
+            {
+                block.BlockAction -= OnBlock;
+            }
+        }
+    }
+}

--- a/src/Effects/VortexBounceEffect.cs
+++ b/src/Effects/VortexBounceEffect.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+
+namespace SWIP.Effects
+{
+    public class VortexBounceEffect : MonoBehaviour
+    {
+        public float pullRadius = 5f;
+        public float pullForce = 800f;
+
+        private Vector3 lastPosition;
+        private Vector3 lastDirection;
+        private bool hasDirection;
+        private float bounceCooldown;
+        private ProjectileHit projectileHit;
+
+        private void Start()
+        {
+            lastPosition = transform.position;
+            projectileHit = GetComponent<ProjectileHit>();
+        }
+
+        private void FixedUpdate()
+        {
+            if (bounceCooldown > 0f) bounceCooldown -= Time.fixedDeltaTime;
+
+            Vector3 currentPos = transform.position;
+            Vector3 delta = currentPos - lastPosition;
+
+            if (delta.sqrMagnitude > 0.01f)
+            {
+                Vector3 currentDir = delta.normalized;
+
+                if (hasDirection && bounceCooldown <= 0f)
+                {
+                    float dot = Vector3.Dot(lastDirection, currentDir);
+                    if (dot < 0.7f)
+                    {
+                        bounceCooldown = 0.15f;
+
+                        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, pullRadius);
+                        foreach (var hit in hits)
+                        {
+                            Player player = hit.GetComponent<Player>();
+                            if (player == null) continue;
+                            if (player.data.dead) continue;
+                            if (projectileHit != null && projectileHit.ownPlayer != null &&
+                                player.teamID == projectileHit.ownPlayer.teamID) continue;
+
+                            Rigidbody2D playerRb = player.GetComponent<Rigidbody2D>();
+                            if (playerRb != null)
+                            {
+                                Vector2 dir = ((Vector2)transform.position - (Vector2)player.transform.position).normalized;
+                                playerRb.AddForce(dir * pullForce);
+                            }
+                        }
+                    }
+                }
+
+                lastDirection = currentDir;
+                hasDirection = true;
+            }
+
+            lastPosition = currentPos;
+        }
+    }
+
+    public class VortexBounceSpawner : ProjectileEffectSpawner
+    {
+        public float pullRadius = 5f;
+        public float pullForce = 800f;
+
+        protected override void ApplyToProjectile(GameObject projectile)
+        {
+            var effect = projectile.AddComponent<VortexBounceEffect>();
+            effect.pullRadius = pullRadius;
+            effect.pullForce = pullForce;
+        }
+    }
+}

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -180,9 +180,88 @@ namespace SWIP
             CustomCard.BuildCard<Nullifier>(ci => CardRegistry.Register("Nullifier", ci));
             CustomCard.BuildCard<TheFinalBoss>(ci => CardRegistry.Register("The Final Boss", ci));
 
+            // === Radial Shot + Bullet Adders ===
+            CustomCard.BuildCard<RadialSpread>(ci => CardRegistry.Register("Radial Spread", ci));
+            CustomCard.BuildCard<BulletStorm>(ci => CardRegistry.Register("Bullet Storm", ci));
+            CustomCard.BuildCard<BulletHail>(ci => CardRegistry.Register("Bullet Hail", ci));
+            CustomCard.BuildCard<BulletFlood>(ci => CardRegistry.Register("Bullet Flood", ci));
+
+            // === Clip Dump ===
+            CustomCard.BuildCard<ClipDump>(ci => CardRegistry.Register("Clip Dump", ci));
+            CustomCard.BuildCard<ClipPurge>(ci => CardRegistry.Register("Clip Purge", ci));
+            CustomCard.BuildCard<ClipApocalypse>(ci => CardRegistry.Register("Clip Apocalypse", ci));
+
+            // === Slow Cards ===
+            CustomCard.BuildCard<SlowDrip>(ci => CardRegistry.Register("Slow Drip", ci));
+            CustomCard.BuildCard<SlowPour>(ci => CardRegistry.Register("Slow Pour", ci));
+            CustomCard.BuildCard<SlowTide>(ci => CardRegistry.Register("Slow Tide", ci));
+
+            // === Bounce Count Cards ===
+            CustomCard.BuildCard<BounceX2>(ci => CardRegistry.Register("Bounce x2", ci));
+            CustomCard.BuildCard<BounceX5>(ci => CardRegistry.Register("Bounce x5", ci));
+            CustomCard.BuildCard<BounceX10>(ci => CardRegistry.Register("Bounce x10", ci));
+            CustomCard.BuildCard<BounceX25>(ci => CardRegistry.Register("Bounce x25", ci));
+            CustomCard.BuildCard<BounceX50>(ci => CardRegistry.Register("Bounce x50", ci));
+            CustomCard.BuildCard<BounceX100>(ci => CardRegistry.Register("Bounce x100", ci));
+
+            // === Bounce Modifier Cards ===
+            CustomCard.BuildCard<RicochetRoulette>(ci => CardRegistry.Register("Ricochet Roulette", ci));
+            CustomCard.BuildCard<Featherfall>(ci => CardRegistry.Register("Featherfall", ci));
+            CustomCard.BuildCard<ChaosRicochet>(ci => CardRegistry.Register("Chaos Ricochet", ci));
+            CustomCard.BuildCard<VortexBounce>(ci => CardRegistry.Register("Vortex Bounce", ci));
+            CustomCard.BuildCard<ShockwaveBounce>(ci => CardRegistry.Register("Shockwave Bounce", ci));
+            CustomCard.BuildCard<IceRicochet>(ci => CardRegistry.Register("Ice Ricochet", ci));
+            CustomCard.BuildCard<ScorchingBounce>(ci => CardRegistry.Register("Scorching Bounce", ci));
+
+            // === Stat Boost Cards ===
+            CustomCard.BuildCard<WideSpread>(ci => CardRegistry.Register("Wide Spread", ci));
+            CustomCard.BuildCard<BulletSpeedPlus>(ci => CardRegistry.Register("Bullet Speed+", ci));
+            CustomCard.BuildCard<RapidFire>(ci => CardRegistry.Register("Rapid Fire", ci));
+
+            // === Ammo/Reload Cards ===
+            CustomCard.BuildCard<InfiniteAmmo>(ci => CardRegistry.Register("Infinite Ammo", ci));
+            CustomCard.BuildCard<QuickDraw>(ci => CardRegistry.Register("Quick Draw", ci));
+
+            // === Unique Mechanic Cards ===
+            CustomCard.BuildCard<BulletWarp>(ci => CardRegistry.Register("Bullet Warp", ci));
+            CustomCard.BuildCard<SnakeRain>(ci => CardRegistry.Register("Snake Rain", ci));
+            CustomCard.BuildCard<SpeedDemon>(ci => CardRegistry.Register("Speed Demon", ci));
+            CustomCard.BuildCard<ChaosStats>(ci => CardRegistry.Register("Chaos Stats", ci));
+            CustomCard.BuildCard<RisingTide>(ci => CardRegistry.Register("Rising Tide", ci));
+            CustomCard.BuildCard<DoubleDown>(ci => CardRegistry.Register("Double Down", ci));
+            CustomCard.BuildCard<AllIn>(ci => CardRegistry.Register("All In", ci));
+            CustomCard.BuildCard<EffectAmplifier>(ci => CardRegistry.Register("Effect Amplifier", ci));
+
+            // === Card Manipulation Cards ===
+            CustomCard.BuildCard<NewHand>(ci => CardRegistry.Register("New Hand", ci));
+            CustomCard.BuildCard<AllInOne>(ci => CardRegistry.Register("All-In-One", ci));
+            CustomCard.BuildCard<CardThief>(ci => CardRegistry.Register("Card Thief", ci));
+            CustomCard.BuildCard<ShuffleAndDeal>(ci => CardRegistry.Register("Shuffle & Deal", ci));
+            CustomCard.BuildCard<CardTornado>(ci => CardRegistry.Register("Card Tornado", ci));
+            CustomCard.BuildCard<HighStakes>(ci => CardRegistry.Register("High Stakes", ci));
+            CustomCard.BuildCard<StatLeech>(ci => CardRegistry.Register("Stat Leech", ci));
+            CustomCard.BuildCard<Copycat>(ci => CardRegistry.Register("Copycat", ci));
+
+            // === Custom Projectile Cards ===
+            CustomCard.BuildCard<AngryBirds>(ci => CardRegistry.Register("Angry Birds", ci));
+            CustomCard.BuildCard<SquidInk>(ci => CardRegistry.Register("Squid Ink", ci));
+
+            // === On-Block/On-Hit Spawner Cards ===
+            CustomCard.BuildCard<NachoBlock>(ci => CardRegistry.Register("Nacho Block", ci));
+            CustomCard.BuildCard<LemonDrop>(ci => CardRegistry.Register("Lemon Drop", ci));
+            CustomCard.BuildCard<TortillaShield>(ci => CardRegistry.Register("Tortilla Shield", ci));
+
             // === Inert Replacement Cards (for card-swap safety) ===
             CustomCard.BuildCard<YayMyTurn>(ci => CardRegistry.Register("Yay It's My Turn!", ci));
             CustomCard.BuildCard<SharingIsCaring>(ci => CardRegistry.Register("Sharing is Caring", ci));
+            CustomCard.BuildCard<NewHandPlaceholder>(ci => CardRegistry.Register("New Hand Used", ci));
+            CustomCard.BuildCard<AllInOnePlaceholder>(ci => CardRegistry.Register("All-In-One Used", ci));
+            CustomCard.BuildCard<CardThiefPlaceholder>(ci => CardRegistry.Register("Card Thief Used", ci));
+            CustomCard.BuildCard<ShuffleDealPlaceholder>(ci => CardRegistry.Register("Shuffle & Deal Used", ci));
+            CustomCard.BuildCard<CardTornadoPlaceholder>(ci => CardRegistry.Register("Card Tornado Used", ci));
+            CustomCard.BuildCard<HighStakesPlaceholder>(ci => CardRegistry.Register("High Stakes Used", ci));
+            CustomCard.BuildCard<StatLeechPlaceholder>(ci => CardRegistry.Register("Stat Leech Used", ci));
+            CustomCard.BuildCard<CopycatPlaceholder>(ci => CardRegistry.Register("Copycat Used", ci));
 
             // === Debug/Test Cards ===
             CustomCard.BuildCard<OrbitalTest>(ci => CardRegistry.Register("Orbital Test", ci));

--- a/thunderstore/CHANGELOG.md
+++ b/thunderstore/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 All notable changes to SWIP (Sam's Wonderful Impressive Card Park) will be documented in this file.
 
+## [2.3.0] - 2026-03-03
+
+### Added — Silly/Chaos Card Pack (~50 new unclassed cards)
+
+**Radial Shot & Bullet Adders (4):**
+- Radial Spread (Uncommon), Bullet Storm (Uncommon), Bullet Hail (Rare), Bullet Flood (Epic)
+
+**Clip Dump (3):**
+- Clip Dump (Uncommon), Clip Purge (Rare), Clip Apocalypse (Epic)
+
+**Slow Cards (3):**
+- Slow Drip (Common), Slow Pour (Uncommon), Slow Tide (Rare)
+
+**Bounce Count Cards (6):**
+- Bounce x2 (Common), Bounce x5 (Common), Bounce x10 (Uncommon), Bounce x25 (Rare), Bounce x50 (Epic), Bounce x100 (Legendary)
+- All include screen-edge bouncing via ScreenBounceEffect
+
+**Bounce Modifier Cards (7):**
+- Ricochet Roulette (Uncommon), Featherfall (Uncommon), Shockwave Bounce (Uncommon), Ice Ricochet (Uncommon)
+- Chaos Ricochet (Rare), Vortex Bounce (Rare), Scorching Bounce (Rare)
+
+**Stat Boost Cards (3):**
+- Wide Spread (Common), Bullet Speed+ (Common), Rapid Fire (Common)
+
+**Ammo/Reload Cards (2):**
+- Infinite Ammo (Legendary), Quick Draw (Rare)
+
+**Unique Mechanic Cards (8):**
+- Bullet Warp (Epic) — teleport to bullet hit location
+- Snake Rain (Rare) — homing snakes spawn when hit
+- Speed Demon (Uncommon) — swap movespeed for damage
+- Chaos Stats (Rare) — randomize 2 stat pairs
+- Rising Tide (Rare) — boost above-baseline stats +20%
+- Double Down (Uncommon) — 50/50 double or halve weak stats
+- All In (Epic) — randomize all stats +/-50%
+- Effect Amplifier (Epic) — boost all effect sizes x1.5
+
+**Card Manipulation Cards (8):**
+- New Hand (Epic) — replace own hand with random cards
+- All-In-One (Legendary) — all cards become copies of 1 random
+- Card Thief (Rare) — force others to swap random cards
+- Shuffle & Deal (Epic) — others shuffle and redraw
+- Card Tornado (Legendary) — all players' cards pooled and redistributed
+- High Stakes (Rare) — gamble to steal/lose stats vs others
+- Stat Leech (Epic) — siphon better stats from other players
+- Copycat (Legendary) — clone any card for entire hand
+
+**Custom Projectile Cards (2):**
+- Angry Birds (Epic) — homing bird projectiles with swooping arcs
+- Squid Ink (Epic) — homing squids with sinusoidal swim + ink cloud slow
+
+**On-Block/On-Hit Spawner Cards (3):**
+- Nacho Block (Uncommon) — spawn nachos on block (heal allies, damage enemies)
+- Lemon Drop (Rare) — blinding lemon zones on hit/bounce
+- Tortilla Shield (Rare) — invulnerable wrap on block (3s, immobile)
+
+### Added — New Effects (18)
+- RadialShotEffect — distributes bullets at equal angles (360/count)
+- ScreenBounceEffect — bounces bullets off camera viewport edges
+- ClipDumpEffect — forces rapid-fire entire clip on trigger
+- SlowOnHitEffect — applies slow debuff on hit (mint green visual)
+- FeatherfallBounceEffect — reduces gravity per bounce
+- ChaosRicochetEffect — swaps damage/speed on bounce
+- VortexBounceEffect — pulls enemies toward bounce point
+- ShockwaveBounceEffect — pushes enemies away from bounce point
+- IceRicochetEffect — slows enemies near bounce point
+- ScorchingBounceEffect — burns near bounce (escalates per bounce)
+- BounceRandomSizeEffect — random size change + speed up on bounce
+- TeleportToBulletEffect — teleports owner to bullet hit location
+- SnakeRainEffect + SnakeHomingBehaviour — wavy homing snakes
+- HomingBirdEffect + BirdHomingBehaviour — swooping homing birds
+- HomingSquidEffect + SquidHomingBehaviour — swimming squids with ink clouds
+- NachosOnBlockEffect + NachoProjectile — radial nacho burst on block
+- TortillaWrapEffect — invulnerable carb shell on block
+- LemonDropEffect — blinding lemon zones on hit/bounce
+
+### Added — Inert Placeholders (8)
+- New Hand Used, All-In-One Used, Card Thief Used, Shuffle & Deal Used, Card Tornado Used, High Stakes Used, Stat Leech Used, Copycat Used
+
+### Changed
+- BrotherlyLove dangerous cards set expanded to include all new manipulation cards
+- BrotherlyLove dangerousCards/replacements made public static for extensibility
+
 ## [2.2.0] - 2026-03-02
 
 ### Fixed — Playtest Issues (#9–#17)

--- a/thunderstore/manifest.json
+++ b/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "SWIP",
-	"version_number": "2.2.0",
+	"version_number": "2.3.0",
 	"website_url": "https://github.com/SLO42/swip",
 	"description": "Sam's Wonderful Impressive Card Park - A custom card pack for ROUNDS",
 	"dependencies": [


### PR DESCRIPTION
## Summary

- **75 new files**: 18 effect files + 49 card files + 8 placeholder cards
- **5,011 lines** of new code across radial shots, bullet spam, bounces, bounce modifiers, stat manipulation, card manipulation, custom projectiles, and on-block spawners
- Version bump to **2.3.0**
- Build succeeds with **0 errors, 0 warnings**

### New Card Groups

| Group | Cards | Rarity Range |
|-------|-------|-------------|
| Radial Shot + Bullet Adders | 4 | Uncommon - Epic |
| Clip Dump | 3 | Uncommon - Epic |
| Slow Cards | 3 | Common - Rare |
| Bounce Count (x2 to x100) | 6 | Common - Legendary |
| Bounce Modifiers | 7 | Uncommon - Rare |
| Stat Boost | 3 | Common |
| Ammo/Reload | 2 | Rare - Legendary |
| Unique Mechanics | 8 | Uncommon - Epic |
| Card Manipulation | 8 | Rare - Legendary |
| Custom Projectiles | 2 | Epic |
| On-Block/On-Hit Spawners | 3 | Uncommon - Rare |
| **Inert Placeholders** | **8** | — |

### New Effects (18)
Bounce detection (dot product), screen-edge bouncing, clip dump rapid fire, slow debuff, gravity reduction, damage/speed swap, enemy pull/push, ice/burn on bounce, random size, teleport-to-bullet, homing snakes/birds/squids, nacho burst, tortilla wrap, lemon zones.

### Modified Files
- `Plugin.cs` — 57 new `BuildCard<>` registrations
- `BrotherlyLove.cs` — expanded dangerous cards set (public static) with all 8 new manipulation card names + replacements

## Test plan
- [ ] `dotnet build src/SWIP.csproj -c Release` passes (verified)
- [ ] All cards appear in card selection screen in-game
- [ ] Bounce cards work with screen-edge reflection
- [ ] Card manipulation cards self-replace with placeholders after use
- [ ] Homing projectiles (birds, squids, snakes) track enemies correctly
- [ ] BrotherlyLove correctly replaces all manipulation cards during swap